### PR TITLE
Add asciidoctor-web-pdf as a bin alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "npm": ">=6.0.0"
   },
   "bin": {
-    "asciidoctor-pdf": "bin/asciidoctor-pdf"
+    "asciidoctor-pdf": "bin/asciidoctor-pdf",
+    "asciidoctor-web-pdf": "bin/asciidoctor-pdf"
   },
   "files": [
     "bin",


### PR DESCRIPTION
Add `asciidoctor-web-pdf` as bin name.
First step toward the new name "asciidoctor-web-pdf".

I kept `asciidoctor-pdf` to avoid disruption.