### PR TITLE
resolves #147 support docinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ node_modules/
 *_temp.html
 /test/output/*.pdf
 /test/fixtures/*.html
+!/test/fixtures/*docinfo*-pdf.html
 /test/output/visual-comparison-workdir/

--- a/README.md
+++ b/README.md
@@ -233,6 +233,14 @@ You can also specify where the stylesheets are located with the `stylesdir` attr
 You can add custom content to the head, header or footer of the output document using docinfo files.
 Docinfo files are useful for injecting auxiliary metadata, stylesheet, and script information into the output not added by the converter.
 
+In addition, you can add running content to the output document.
+Running content can then be positioned via CSS on the [top, bottom, left or right margins of pages](https://www.w3.org/TR/css-page-3/#margin-boxes).
+This can come in handy when you want to repeat complex elements (address, contact...) on all pages for documents like invoices or reports.
+If you want to learn more about running elements, please read the following section **Running elements**.
+
+**IMPORTANT**: You will need to declare running elements as running content via CSS.
+Otherwise, running elements will be visible on the page. 
+
 To enable docinfo files, you need to configure the scope using the `docinfo` attribute.
 The scope defines if the docinfo files apply for a specific document ("private") or for all documents in the same directory ("shared").
 
@@ -241,20 +249,24 @@ The scope defines if the docinfo files apply for a specific document ("private")
 | Private | Head   | Adds content to `<head>` for `<docname>.adoc` files. | `<docname>-docinfo-pdf.html` |
 | Private | Header | Adds content to start of document for `<docname>.adoc` files. | `<docname>-docinfo-header-pdf.html` |
 | Private | Footer | Adds content to end of document for `<docname>.adoc` files. | `<docname>-docinfo-footer-pdf.html` |
+| Private | Running | Adds running content to start of document for `<docname>.adoc` files. | `<docname>-docinfo-running-pdf.html` |
 | Shared | Head | Adds content to `<head>` for any document in same directory. | `docinfo-pdf.html` |
 | Shared | Header | Adds content to start of document for any document in same directory. | `docinfo-header-pdf.html` |
 | Shared | Footer | Adds content to end of document for any document in same directory. | `docinfo-footer-pdf.html` |
+| Shared | Running | Adds running content to start for any document in same directory. | `docinfo-running-pdf.html` |
 
 To specify which file(s) you want to apply, set the docinfo attribute to any combination of these values:
 
 - `private-head`
 - `private-header`
 - `private-footer`
-- `private` (alias for `private-head,private-header,private-footer`)
+- `private-running`
+- `private` (alias for `private-head,private-header,private-footer,private-running`)
 - `shared-head`
 - `shared-header`
 - `shared-footer`
-- `shared` (alias for `shared-head,shared-header,shared-footer`)
+- `shared-running`
+- `shared` (alias for `shared-head,shared-header,shared-footer,shared-running`)
 
 Setting `docinfo` with no value is equivalent to setting the value to `private`.
 
@@ -264,8 +276,43 @@ For example:
 :docinfo: shared,private-footer
 ```
 
-This docinfo configuration will apply the shared docinfo head, header and footer files, if they exist, as well as the private footer file, if it exists.
+This docinfo configuration will apply the shared docinfo head, header, running and footer files, if they exist, as well as the private footer file, if it exists.
 
+**Running elements**
+
+Running elements can be positioned on the [top, bottom, left or right margins of pages](https://www.w3.org/TR/css-page-3/#margin-boxes).
+Let's take a concrete example where we want to display an address block in the bottom left box of every page.
+
+```html
+<address class="contact-us">
+  <strong>Example Inc.</strong><br>
+  1234 Example Street<br>
+  Antartica, Example 0987<br>
+  <abbr title="Phone">P:</abbr> (123) 456-7890
+</address>
+```
+
+First, you will to define your element as running using the `position` property.
+Here, we are using `runningContact` as an identifier, but you can use any name that makes sense to you:
+
+```css
+.contact-us {
+  position: running(runningContact)
+}
+```
+
+Then, place the element into a margin box with the `element()` function via the `content` property:
+
+```css
+@page {
+  @bottom-left {
+    content: element(runningContact)
+  }
+}
+```
+
+As you can see, we are using the identifier `runningContact` defined earlier.
+The above definition will effectively remove the `.contact-us` element from the page and repeat it on every page in the bottom left box.
 
 **Asciidoctor extensions**
 

--- a/README.md
+++ b/README.md
@@ -214,18 +214,58 @@ You can provide a custom stylesheet using the `stylesheet` attribute. A custom s
 
     $ asciidoctor-web-pdf document.adoc -a stylesheet="custom.css"
 
-The `stylesheet` attribute can accept multiple comma delimited values (without spaces).
+The `stylesheet` attribute can accept multiple comma-delimited values (without spaces).
 This can be used to begin with a base stylesheet and then apply supplementary content.
 
     $ asciidoctor-web-pdf document.adoc -a stylesheet="custom.css,override.css"
 
-It's also possible to use the default stylesheet and add custom styles with a custom stylesheet. All default stylesheets are available under the prefix `asciidoctor-pdf/css/`:
+It's also possible to use the default stylesheet and add custom styles with a custom stylesheet.
+All default stylesheets are available under the prefix `asciidoctor-pdf/css/`:
 
     $ asciidoctor-web-pdf document.adoc -a stylesheet="asciidoctor-pdf/css/asciidoctor.css,asciidoctor-pdf/css/document.css,custom.css"
 
 You can also specify where the stylesheets are located with the `stylesdir` attribute.
 
     $ asciidoctor-web-pdf document.adoc -a stylesdir=css -a stylesheet="custom.css,override.css"
+
+**Docinfo**
+
+You can add custom content to the head, header or footer of the output document using docinfo files.
+Docinfo files are useful for injecting auxiliary metadata, stylesheet, and script information into the output not added by the converter.
+
+To enable docinfo files, you need to configure the scope using the `docinfo` attribute.
+The scope defines if the docinfo files apply for a specific document ("private") or for all documents in the same directory ("shared").
+
+| Mode	| Location | Behavior | Docinfo file name |
+| ----- | -------- | -------- | ----------------- |
+| Private | Head   | Adds content to `<head>` for `<docname>.adoc` files. | `<docname>-docinfo-pdf.html` |
+| Private | Header | Adds content to start of document for `<docname>.adoc` files. | `<docname>-docinfo-header-pdf.html` |
+| Private | Footer | Adds content to end of document for `<docname>.adoc` files. | `<docname>-docinfo-footer-pdf.html` |
+| Shared | Head | Adds content to `<head>` for any document in same directory. | `docinfo-pdf.html` |
+| Shared | Header | Adds content to start of document for any document in same directory. | `docinfo-header-pdf.html` |
+| Shared | Footer | Adds content to end of document for any document in same directory. | `docinfo-footer-pdf.html` |
+
+To specify which file(s) you want to apply, set the docinfo attribute to any combination of these values:
+
+- `private-head`
+- `private-header`
+- `private-footer`
+- `private` (alias for `private-head,private-header,private-footer`)
+- `shared-head`
+- `shared-header`
+- `shared-footer`
+- `shared` (alias for `shared-head,shared-header,shared-footer`)
+
+Setting `docinfo` with no value is equivalent to setting the value to `private`.
+
+For example:
+
+```
+:docinfo: shared,private-footer
+```
+
+This docinfo configuration will apply the shared docinfo head, header and footer files, if they exist, as well as the private footer file, if it exists.
+
 
 **Asciidoctor extensions**
 

--- a/lib/document/document-converter.js
+++ b/lib/document/document-converter.js
@@ -84,13 +84,16 @@ ${this.fontAwesomeStyle(node)}
 ${this.styles(node)}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 ${this.syntaxHighlighterHead(node, syntaxHighlighter, { cdn_base_url: cdnBaseUrl, linkcss: linkcss, self_closing_tag_slash: '/' })}
+${this.docinfoContent(node, 'head', '-pdf.html')}
 </head>
 <body ${bodyAttrs.join(' ')}>
+${this.docinfoContent(node, 'header', '-pdf.html')}
 ${this.titlePage(node)}
 ${this.outline(node, opts)}
 ${this.tocHeader(node, opts)}
 ${contentHTML}
 ${this.footnotes(node)}
+${this.docinfoContent(node, 'footer', '-pdf.html')}
 ${this.syntaxHighlighterFooter(node, syntaxHighlighter, { cdn_base_url: cdnBaseUrl, linkcss: linkcss, self_closing_tag_slash: '/' })}
 ${this.stemContent.content(node)}
 <script>
@@ -408,6 +411,14 @@ ${this.documentTypeStyle(node)}
       return `<style>
 ${faDom.css()}
 </style>`
+    }
+    return ''
+  }
+
+  docinfoContent(node, docinfoLocation, suffix) {
+    const docinfoContent = node.getDocinfo(docinfoLocation, suffix)
+    if (docinfoContent) {
+      return docinfoContent
     }
     return ''
   }

--- a/lib/document/document-converter.js
+++ b/lib/document/document-converter.js
@@ -88,6 +88,7 @@ ${this.docinfoContent(node, 'head', '-pdf.html')}
 </head>
 <body ${bodyAttrs.join(' ')}>
 ${this.docinfoContent(node, 'header', '-pdf.html')}
+${this.docinfoContent(node, 'running', '-pdf.html')}
 ${this.titlePage(node)}
 ${this.outline(node, opts)}
 ${this.tocHeader(node, opts)}

--- a/test/document_convert_test.js
+++ b/test/document_convert_test.js
@@ -25,4 +25,30 @@ Guillaume Grossetie
     const $ = cheerio.load(doc.convert({ header_footer: true }))
     expect($('h1').text()).to.equal('Static title')
   })
+
+  describe('Docinfo', () => {
+    it('should include shared (head) docinfo', () => {
+      asciidoctor.ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
+      const $ = cheerio.load(asciidoctor.convertFile(`${__dirname}/fixtures/simple.adoc`, {
+        safe: 'safe',
+        backend: 'web-pdf',
+        header_footer: true,
+        to_file: false,
+        attributes: { docinfo: 'shared' }
+      }))
+      expect($('head > meta[name="keywords"]').attr('content')).to.equal('journalism, press')
+      expect($('head > script[src="debug.js"]').length).to.equal(1)
+    })
+    it('should include private (footer) docinfo', () => {
+      asciidoctor.ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
+      const $ = cheerio.load(asciidoctor.convertFile(`${__dirname}/fixtures/simple.adoc`, {
+        safe: 'safe',
+        backend: 'web-pdf',
+        header_footer: true,
+        to_file: false,
+        attributes: { docinfo: 'private-footer' }
+      }))
+      expect($('footer').text()).to.equal('This is the end.')
+    })
+  })
 })

--- a/test/document_convert_test.js
+++ b/test/document_convert_test.js
@@ -1,5 +1,6 @@
 /* global it, describe */
 const cheerio = require('cheerio')
+const ospath = require('path')
 const chai = require('chai')
 const expect = chai.expect
 const dirtyChai = require('dirty-chai')
@@ -7,6 +8,8 @@ chai.use(dirtyChai)
 
 const asciidoctor = require('@asciidoctor/core')()
 const DocumentConverter = require('../lib/document/document-converter')
+
+const fixturesPath = (...paths) => ospath.join(__dirname, 'fixtures', ...paths)
 
 describe('Document converter', () => {
   it('should override the titlePage function', () => {
@@ -29,7 +32,7 @@ Guillaume Grossetie
   describe('Docinfo', () => {
     it('should include shared (head) docinfo', () => {
       asciidoctor.ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
-      const $ = cheerio.load(asciidoctor.convertFile(`${__dirname}/fixtures/simple.adoc`, {
+      const $ = cheerio.load(asciidoctor.convertFile(fixturesPath('simple.adoc'), {
         safe: 'safe',
         backend: 'web-pdf',
         header_footer: true,
@@ -41,7 +44,7 @@ Guillaume Grossetie
     })
     it('should include private (footer) docinfo', () => {
       asciidoctor.ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
-      const $ = cheerio.load(asciidoctor.convertFile(`${__dirname}/fixtures/simple.adoc`, {
+      const $ = cheerio.load(asciidoctor.convertFile(fixturesPath('simple.adoc'), {
         safe: 'safe',
         backend: 'web-pdf',
         header_footer: true,
@@ -49,6 +52,17 @@ Guillaume Grossetie
         attributes: { docinfo: 'private-footer' }
       }))
       expect($('footer').text()).to.equal('This is the end.')
+    })
+    it('should include private (running) docinfo', () => {
+      asciidoctor.ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
+      const $ = cheerio.load(asciidoctor.convertFile(fixturesPath('simple.adoc'), {
+        safe: 'safe',
+        backend: 'web-pdf',
+        header_footer: true,
+        to_file: false,
+        attributes: { docinfo: 'private-running' }
+      }))
+      expect($('body > .contact-us').length).to.equal(1)
     })
   })
 })

--- a/test/fixtures/debug.js
+++ b/test/fixtures/debug.js
@@ -1,0 +1,1 @@
+console.log('debug');

--- a/test/fixtures/docinfo-pdf.html
+++ b/test/fixtures/docinfo-pdf.html
@@ -1,0 +1,3 @@
+<meta name="keywords" content="journalism, press">
+<link rel="stylesheet" href="press.css">
+<script src="debug.js"></script>

--- a/test/fixtures/press.css
+++ b/test/fixtures/press.css
@@ -1,0 +1,4 @@
+html {
+  font: 11pt 'Helvetica', serif;
+}
+

--- a/test/fixtures/simple-docinfo-footer-pdf.html
+++ b/test/fixtures/simple-docinfo-footer-pdf.html
@@ -1,0 +1,1 @@
+<footer>This is the end.</footer>

--- a/test/fixtures/simple-docinfo-running-pdf.html
+++ b/test/fixtures/simple-docinfo-running-pdf.html
@@ -1,0 +1,6 @@
+<address class="contact-us">
+  <strong>Example Inc.</strong><br>
+  1234 Example Street<br>
+  Antartica, Example 0987<br>
+  <abbr title="Phone">P:</abbr> (123) 456-7890
+</address>


### PR DESCRIPTION
The header docinfo is located just after `<body>`.
The footer docinfo is located at the end of the document before `</body>`.

The users might expect to be able to configure the top and bottom margins of each page using a docinfo file but, as far as I know, it's not possible to do so...

resolves #147