### PR TITLE
Repeat direct children on table

### DIFF
--- a/lib/document/repeating-table-elements.js
+++ b/lib/document/repeating-table-elements.js
@@ -14,11 +14,11 @@ class RepeatingTableElements extends Paged.Handler {
       // Find the node in the original source
       const sourceTable = chunker.source.querySelector("[data-ref='" + ref + "']")
       // Repeat the <thead> element (if exists)
-      this.repeatElement(sourceTable, table, 'thead')
+      this.repeatElement(sourceTable, table, ':scope > thead')
       // Repeat the <colgroup> elements (if at least one exists)
-      this.repeatElements(sourceTable, table, 'colgroup')
+      this.repeatElements(sourceTable, table, ':scope > colgroup')
       // Repeat the <caption> element (if exists)
-      this.repeatElement(sourceTable, table, 'caption')
+      this.repeatElement(sourceTable, table, ':scope > caption')
     })
   }
 


### PR DESCRIPTION
Otherwise, if the table has a nested table with a `<colgroup>`, the element will be repeated on the root table.