### PR TITLE
ref #286 add a deprecation warning when using asciidoctor-pdf

### DIFF
--- a/bin/asciidoctor-web-pdf
+++ b/bin/asciidoctor-web-pdf
@@ -2,11 +2,10 @@
 
 'use strict'
 
-process.title = 'asciidoctor-pdf'
+process.title = 'asciidoctor-web-pdf'
 const { PdfOptions, PdfInvoker } = require('../lib/cli.js')
 
 ;(async () => {
-  console.warn('WARN: `asciidoctor-pdf` is deprecated and will be removed in a future version, please use `asciidoctor-web-pdf` instead')
   const options = new PdfOptions().parse(process.argv)
   return new PdfInvoker(options).invoke()
 })()

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "bin": {
     "asciidoctor-pdf": "bin/asciidoctor-pdf",
-    "asciidoctor-web-pdf": "bin/asciidoctor-pdf"
+    "asciidoctor-web-pdf": "bin/asciidoctor-web-pdf"
   },
   "files": [
     "bin",


### PR DESCRIPTION
```console
$ asciidoctor-pdf doc.adoc 
WARN: `asciidoctor-pdf` is deprecated and will be removed in a future version, please use `asciidoctor-web-pdf` instead
```
```console
$ asciidoctor-web-pdf doc.adoc
```

What do you think? Is that explicit enough? I don't want to explain the "why" in the message to keep it short but we might add a reference to the GitHub issue?

ref #286

//cc @djencks 