### PR TITLE
resolves #298 allow to include style sheets in addition to the default styles using '+' prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,13 @@ You can provide a custom stylesheet using the `stylesheet` attribute. A custom s
 
     $ asciidoctor-web-pdf document.adoc -a stylesheet="custom.css"
 
+**TIP:** You can also provide a custom stylesheet **in addition** to all the default styles using the `+` prefix:
+
+    $ asciidoctor-web-pdf document.adoc -a stylesheet="+custom.css"
+
+Notice the `+` before `custom.css`, it means that the stylesheet will be included after all the default styles.
+This is particularly useful when you want to override a few styles.
+
 The `stylesheet` attribute can accept multiple comma-delimited values (without spaces).
 This can be used to begin with a base stylesheet and then apply supplementary content.
 

--- a/lib/document/document-converter.js
+++ b/lib/document/document-converter.js
@@ -326,6 +326,16 @@ ${node.getContent()}
 
   styles (node) {
     const stylesheetAttribute = node.getAttribute('stylesheet')
+    // stylesheet attribute was unset using `stylesheet!` (default value is '')
+    if (typeof stylesheetAttribute === 'undefined') {
+      return ''
+    }
+    const defaultStyles = `<style>
+${this.asciidoctorStyleContent}
+${this.documentStyleContent}
+${this.titlePageStyle(node)}
+${this.documentTypeStyle(node)}
+</style>`
     if (stylesheetAttribute && stylesheetAttribute.trim() !== '') {
       let separator = ','
       // REMIND for backward compatibility, will be removed in a future version
@@ -333,9 +343,9 @@ ${node.getContent()}
         console.warn('Using semi-colon \';\' as a separator is deprecated and will be removed in a future version. Please use comma \',\' as a separator instead.')
         separator = ';'
       }
-      return stylesheetAttribute
+      const customStyles = stylesheetAttribute
         .split(separator)
-        .map(value => value.trim())
+        .map(value => value.trim().replace(/^\+/, ""))
         .filter(value => value !== '')
         .map(stylesheet => {
           let href
@@ -365,13 +375,12 @@ ${node.getContent()}
           return `<link href="${href}" rel="stylesheet">`
         })
         .join('\n')
+      if (stylesheetAttribute.startsWith('+')) {
+        return defaultStyles + customStyles
+      }
+      return customStyles
     }
-    return `<style>
-${this.asciidoctorStyleContent}
-${this.documentStyleContent}
-${this.titlePageStyle(node)}
-${this.documentTypeStyle(node)}
-</style>`
+    return defaultStyles
   }
 
   titlePageStyle (node) {


### PR DESCRIPTION
It was already possible to provide a custom style in addition to the default style but the user had to explicitly include the several style sheets: `asciidoctor-pdf/css/asciidoctor.css`, `asciidoctor-pdf/css/document.css`.
Some styles are also conditionally included depending on the document type and document attributes: `asciidoctor-pdf/css/features/book.css`, `asciidoctor-pdf/css/features/title-document-numbering.css`, `asciidoctor-pdf/css/title-page.css`
In short, it was not practical!

Now, you can provide a custom style sheet in addition to the default style sheets using `+` as a prefix.
The following command will include the style sheet `custom.css` in addition to the default style sheets:

```command
$ asciidoctor-web-pdf -a stylesheet=+custom.css doc.adoc
```

It's also now possible to disable all the styles by unsetting the `stylesheet` attribute:

```command
$ asciidoctor-web-pdf -a stylesheet\! doc.adoc # `!` needs to be escaped in Bash
```

Please note that this does not disable Paged.js built-in styles injected at runtime.

resolves #298