### PR TITLE
fix "stream not closed" problem.

### DIFF
--- a/tasks/prepare-binaries.js
+++ b/tasks/prepare-binaries.js
@@ -70,7 +70,7 @@ function copyAssets (platforms) {
 
 async function archive (platforms) {
   console.log('Zipping...')
-  return Object.keys(platforms).map(async (platform) => {
+  return Promise.all(Object.keys(platforms).map(async (platform) => {
     const rootname = `${appName}-${platform}`
     const archive = archiver('zip', {
       zlib: { level: 9 } // Maximize compression
@@ -96,7 +96,7 @@ async function archive (platforms) {
 
     const archiveFinalize = archive.finalize()
     return Promise.all([zipClose, archiveFinalize])
-  })
+  }))
 }
 
 async function main (platforms) {

--- a/tasks/prepare-binaries.js
+++ b/tasks/prepare-binaries.js
@@ -114,13 +114,13 @@ async function asyncMain (platforms) {
     fsExtra.ensureDirSync(chromiumDir)
   }
 
-  if (isDryrun() && true) {
+  if (isDryrun()) {
     console.log('skipping browser download ..')
   } else {
     // get browser
     await getBrowsers(platforms)
   }
-  if (isDryrun() && false) {
+  if (isDryrun()) {
     console.log('skipping package creation ..')
   } else {
     // using pkg create the binary for asciidoctor-web-pdf
@@ -134,10 +134,6 @@ async function asyncMain (platforms) {
 
 function isDryrun () {
   return process.env.DRY_RUN !== undefined
-}
-
-function sleep (milliseconds) {
-  return new Promise(resolve => setTimeout(resolve, milliseconds))
 }
 
 function exit (exitcode) {

--- a/tasks/prepare-binaries.js
+++ b/tasks/prepare-binaries.js
@@ -134,6 +134,13 @@ function isDryrun () {
   return process.env.DRY_RUN !== undefined
 }
 
+function exit (exitcode) {
+  if (isDryrun() && exitcode === 0) {
+    console.warn('dry run: generated output *not* useful for production.')
+  }
+  process.exit(exitcode)
+}
+
 // allow invoking `node tasks/prepare-binaries.js` with linux/mac/win as the argument
 // e.g. `npm run build linux`
 ;(async () => {
@@ -144,11 +151,13 @@ function isDryrun () {
         const singleBuild = {}
         singleBuild[platform] = platforms[platform]
         await main(singleBuild)
+        exit(0)
       } else {
         console.error(`${platform} is not a recognized platform, please use one of: ${Object.keys(platforms)}`)
       }
     } else {
       await main(platforms)
+      exit(0)
     }
   } catch (err) {
     console.error(err)


### PR DESCRIPTION
While working on #456 I run into problems testing locally:

1. Downloading browsers via puppeteer takes endless amount of time (even for a single platform)
2. The command "npm run build" never finished (even if  browser download is skipped)

The first "fix" in this PR allows for rapid local testing of "npm run build" by wrapping `getBrowsers()` and `createPackage()`:

```javascript
  function isDryrun () {
    return process.env.DRY_RUN !== undefined
  }

  ..

  if (isDryrun() && true) {
    console.log('skipping browser download ..')
  } else {
    // get browser
    await getBrowsers(platforms)
  }
```

Here how to test locally:

```
$ DRY_RUN=true npm run build linux
..
skipping browser download ..
Building asciidoctor-web-pdf for: linux
..
Wrote 60.08 Mb total to linux
dry run: generated output *not* useful for production.
```

Notice the warning message that the output created in 'dry-run' mode is not particular useful as such.

The second problem has been more subtle. The documentation of https://www.npmjs.com/package/archiver states:

```
// finalize the archive (ie we are done appending files but streams have to finish yet)
// 'close', 'end' or 'finish' may be fired right after calling this method so register to them beforehand
archive.finalize();
```

So it is not enough to await the end of `archive.finalize()`, we also _need to await the end of streaming_. I introduced a new promise for that:

```
   // must not be in same dir where we are zipping
    const p0 = new Promise((resolve, reject) => {
      zipOut.on('close', function () {
        console.log(`Wrote ${Math.round(archive.pointer() / 1e4) / 1e2} Mb total to ${platform}`)
        resolve()
      })
      zipOut.on('error', reject)
      archive.on('error', reject)
    })
```
and eventually I use Promise.all() await both, the end of archive and streaming.

I tested this locally and it looks promising (correctly creates ZIp file). I wonder though how I can test my changes on my fork? Enable workflows on my fork and create somehow a test release?