### PR TITLE
Pr fix readline issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,9 @@
   ],
   "scripts": {
     "build": "node tasks/prepare-binaries.js",
+    "build-mac": "node tasks/prepare-binaries.js mac",
+    "build-linux": "node tasks/prepare-binaries.js linux",
+    "build-win": "node tasks/prepare-binaries.js win",
     "test": "npm run test:smoke && npm run test:js",
     "test:smoke": "./bin/asciidoctor-pdf --version",
     "test:js": "mocha test/**_test.js",

--- a/tasks/prepare-binaries.js
+++ b/tasks/prepare-binaries.js
@@ -1,22 +1,9 @@
 const path = require('path')
 const fs = require('fs')
 const fsExtra = require('fs-extra')
-const readline = require('readline')
 const archiver = require('archiver')
 const { exec } = require('pkg')
 const puppeteer = require('puppeteer')
-
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-})
-
-// When creating a readline.Interface using stdin as input, the program will not terminate until it
-// receives EOF (Ctrl+D on Linux/macOS, Ctrl+Z followed by Return on Windows). If you want your
-// application to exit without waiting for user input, you can unref the standard input stream.
-// Reference: https://nodejs.org/api/readline.html#readline_readline
-
-process.stdin.unref()
 
 const appName = 'asciidoctor-web-pdf'
 const buildDir = 'build'
@@ -49,9 +36,8 @@ async function getBrowsers (platforms) {
         path: path.resolve(path.join(buildDirPath, name, 'chromium'))
       })
       .download(puppeteer._preferredRevision, function (downloadBytes, totalBytes) {
-        readline.cursorTo(process.stdout, 0)
         const percent = Math.round(downloadBytes / totalBytes * 100)
-        rl.write(`Downloading browser for ${name.padEnd(5)} ${percent.toString().padStart(5)}%`)
+        console.log('\x1B[1A\x1B[K' + `Downloading browser for ${name.padEnd(5)} ${percent.toString().padStart(5)}%`)
       })
   }))
   console.log('\nBrowsers are downloaded/available')


### PR DESCRIPTION
This is a fix for the on-going readline() issue of consuming 100% CPU on running locally `npm run build`.

The fix itself is rather straight-forward. Usage of readline() is completly dropped. Instead ANSI escape chars are used (like mentioned here https://tforgione.fr/posts/ansi-escape-codes):

The relevant section now looks like

```javascript
   await puppeteer
      .createBrowserFetcher({..})
      .download(puppeteer._preferredRevision, function (downloadBytes, totalBytes) {
        const percent = Math.round(downloadBytes / totalBytes * 100)
        console.log('\x1B[1A\x1B[K' + `Downloading browser for ${name.padEnd(5)} ${percent.toString().padStart(5)}%`)
      })
```

Here `\x1B[2K` erases the whole line and also moves the cursor to start of (erased line).

This change works perfectly well on my local MacOS machine, whether running inside IntelliJ's terminal or when using a regular xterm terminal. Download takes time in, well, almost no time while before the CPU consumed all CPU power and finished in about 20 minutes per platform.
