### PR TITLE
proper handling of --version and --help.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -39,6 +39,16 @@ class PdfOptions {
         describe: 'open the otherwise headless browser for inspecting the generated HTML document (before it gets converted to PDF)',
         type: 'boolean'
       })
+
+    // create fine tuned args parser
+    const argsParser = this.options.argsParser()
+      .version(new Invoker().version())
+      .help()
+
+    // override argsParser method to use fine tuned parser
+    this.options.argsParser = () => {
+      return argsParser
+    }
   }
 
   parse (argv) {
@@ -47,15 +57,16 @@ class PdfOptions {
 }
 
 class PdfInvoker extends Invoker {
+  // eslint-disable-next-line no-useless-constructor
+  constructor (options) {
+    super(options)
+  }
+
   async invoke () {
     const cliOptions = this.options
-    const processArgs = cliOptions.argv.slice(2)
     const { args } = cliOptions
-    const { verbose, version, files, watch, 'template-require': templateRequireLib, preview } = args
-    if (version || (verbose && processArgs.length === 1)) {
-      this.showVersion()
-      return { exit: true }
-    }
+    const { verbose, files, watch, 'template-require': templateRequireLib, preview } = args
+
     let templates
     if (templateRequireLib) {
       templates = Invoker.requireLibrary(templateRequireLib)


### PR DESCRIPTION
This PR address proper handling of command-line options --version and --help:

- options --version and --help are shown in displayed help-usage string
- options --version and --help are charged with "veto" super-power 

"veto" super-power:
When option --help or --version is used, then all other arguments are ignored. Option --version has higher priority than option --version (standard and expected behaviour; default behaviour of [yargs](http://yargs.js.org/docs/#api-reference-help) anyway.