### PR TITLE
resolves #633 Introduce PUPPETEER_PRINT_TIMEOUT for puppeteer pdf rendering

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -73,7 +73,7 @@ class Browser {
       await page.goto(url, options)
     }
     // watchdog
-    await page.waitForFunction('window.AsciidoctorPDF === undefined || window.AsciidoctorPDF.status === undefined || window.AsciidoctorPDF.status === "ready"')
+    await page.waitForFunction('window.AsciidoctorPDF === undefined || window.AsciidoctorPDF.status === undefined || window.AsciidoctorPDF.status === "ready"', { timeout: this.renderingTimeout })
     // scroll to element
     if (activePageUrl && activePageUrl.hash) {
       await page.evaluate(id => {

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -73,7 +73,7 @@ class Browser {
       await page.goto(url, options)
     }
     // watchdog
-    await page.waitForFunction('window.AsciidoctorPDF === undefined || window.AsciidoctorPDF.status === undefined || window.AsciidoctorPDF.status === "ready"', { timeout: this.renderingTimeout })
+    await page.waitForFunction('window.AsciidoctorPDF === undefined || window.AsciidoctorPDF.status === undefined || window.AsciidoctorPDF.status === "ready"')
     // scroll to element
     if (activePageUrl && activePageUrl.hash) {
       await page.evaluate(id => {

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -132,7 +132,7 @@ async function convert (processor, inputFile, options, timings, watch, preview) 
   } catch (err) {
     console.error('Unable to generate the PDF - Error: ' + err.toString())
     if (err && err.name === 'TimeoutError') {
-      console.log('> TIP: You can configure the timeout in milliseconds using PUPPETEER_DEFAULT_TIMEOUT, PUPPETEER_NAVIGATION_TIMEOUT or PUPPETEER_RENDERING_TIMEOUT environment variables.')
+      console.log('> TIP: You can configure the timeout in milliseconds using PUPPETEER_DEFAULT_TIMEOUT, PUPPETEER_NAVIGATION_TIMEOUT, PUPPETEER_RENDERING_TIMEOUT or PUPPETEER_PRINT_TIMEOUT environment variables.')
     }
   } finally {
     if (watch || preview) {

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -89,10 +89,14 @@ async function convert (processor, inputFile, options, timings, watch, preview) 
   }
   try {
     const page = await browserInstance.goto(`file://${tempFile}`, preview)
+    const puppeteerDefaultTimeout = process.env.PUPPETEER_DEFAULT_TIMEOUT
+    const printTimeout = process.env.PUPPETEER_PRINT_TIMEOUT || puppeteerDefaultTimeout || 30000
+
     if (!preview) {
       const pdfOptions = {
         printBackground: true,
-        preferCSSPageSize: true
+        preferCSSPageSize: true,
+        timeout: printTimeout
       }
       const pdfWidth = doc.getAttributes()['pdf-width']
       if (pdfWidth) {
@@ -106,9 +110,6 @@ async function convert (processor, inputFile, options, timings, watch, preview) 
       if (format) {
         pdfOptions.format = format // Paper format. If set, takes priority over width or height options. Defaults to 'Letter'.
       }
-
-      // set the puppeteer render timeout (https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagepdfoptions)
-      pdfOptions.timeout = browserInstance.renderingTimeout;
 
       let pdf = await page.pdf(pdfOptions)
       // Outline is not yet implemented in Chromium, so we add it manually here.

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -107,6 +107,9 @@ async function convert (processor, inputFile, options, timings, watch, preview) 
         pdfOptions.format = format // Paper format. If set, takes priority over width or height options. Defaults to 'Letter'.
       }
 
+      // set the puppeteer render timeout (https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagepdfoptions)
+      pdfOptions.timeout = browserInstance.renderingTimeout;
+
       let pdf = await page.pdf(pdfOptions)
       // Outline is not yet implemented in Chromium, so we add it manually here.
       // https://bugs.chromium.org/p/chromium/issues/detail?id=840455


### PR DESCRIPTION
The pull request [#236](https://github.com/Mogztter/asciidoctor-web-pdf/pull/236) did not change the puppeteer rendering timeout - it changes the time asciidoc-web-pdf waits for puppeteer.

According to [puppeteer pdf options](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagepdfoptions) a timeout shall be passed to the page.pdf() call instead.

Rendering of complex documents on slow machines could easily exceed the 30s limit.

Solution: Introduce a PUPPETEER_PRINT_TIMEOUT environment variable that is passed to puppeteer - see [puppeteer pdf timeout option](https://github.com/puppeteer/puppeteer/blob/main/docs/api.md#pagepdfoptions).

Issue: #633