### PR TITLE
Remove orphaned table headers at page breaks

### DIFF
--- a/lib/document/repeating-table-elements.js
+++ b/lib/document/repeating-table-elements.js
@@ -20,6 +20,14 @@ class RepeatingTableElements extends Paged.Handler {
       // Repeat the <caption> element (if exists)
       this.repeatElement(sourceTable, table, ':scope > caption')
     })
+
+    // Remove orphaned table headers at page breaks
+    const fromTables = pageElement.querySelectorAll('table:not([data-split-from])')
+    fromTables.forEach((table) => {
+      if (table.getElementsByTagName('tbody')[0].children.length === 0) {
+        table.parentNode.removeChild(table)
+      }
+    })
   }
 
   repeatElement (sourceTable, table, querySelector) {


### PR DESCRIPTION
When a table spreads across two pages, the header is automatically repeated. However, an orphaned table header could exist on the previous page when the page break occurs exactly after the table header. This PR resolves the above-mentioned problem. 

Signed-off-by: Patrick-LuoYu <patrickluo@yunify.com>