### PR TITLE
Add Docker Usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,39 @@ Verify that the `asciidoctor-web-pdf` command is available on your `PATH` by run
 $ yarn global add @asciidoctor/core asciidoctor-pdf
 ```
 
+### Using Docker
+
+Currently, there is no public image yet pushed in a public docker registry.
+
+Therefore, you can build your own custom docker image.
+
+The base image is from the official [puppeteer](https://github.com/puppeteer/puppeteer/pkgs/container/puppeteer), which contains puppeteer and google-chrome for pdf generation.
+
+To build the docker image. The target image name in this example is `adoc2web`.
+
+```bash
+cd docker
+docker build . -t adoc2web
+```
+
+Check installation in docker container.
+
+```bash
+docker run --rm adoc2web asciidoctor-web-pdf --version
+
+Asciidoctor Web PDF 1.0.0-alpha.14 using Asciidoctor.js 2.2.6 (Asciidoctor 2.0.17) [https://asciidoctor.org]
+Runtime Environment (node v16.17.0 on linux)
+CLI version 3.5.0
+```
+
+To render a cheatsheet for instance
+
+```bash
+docker run --rm \ 
+  --volume $PWD:/usr/src/app adoc2web \ 
+  asciidoctor-web-pdf maven-security-cheat-sheet.adoc --template-require ./snyk/template.js
+```
+
 ## Get started
 
 Asciidoctor Web PDF provides a standard document layout.

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Runtime Environment (node v16.17.0 on linux)
 CLI version 3.5.0
 ```
 
-To render a cheatsheet for instance
+If you want to render the cheatsheet example, move to the root of this repository and type:
 
 ```bash
 docker run --rm \ 

--- a/README.md
+++ b/README.md
@@ -204,13 +204,13 @@ To build the Docker image, clone this repository and type the following commands
 
 ```bash
 cd docker
-docker build . -t adoc2web
+docker build . -t asciidoctor-web-pdf:latest
 ```
 
 Verify that the Docker image is working by running:
 
 ```bash
-docker run --rm adoc2web asciidoctor-web-pdf --version
+docker run --rm asciidoctor-web-pdf asciidoctor-web-pdf --version
 
 Asciidoctor Web PDF 1.0.0-alpha.14 using Asciidoctor.js 2.2.6 (Asciidoctor 2.0.17) [https://asciidoctor.org]
 Runtime Environment (node v16.17.0 on linux)
@@ -221,11 +221,12 @@ If you want to render the cheatsheet example, move to the root of this repositor
 
 ```bash
 docker run --rm \ 
-  --volume $PWD:/usr/src/app adoc2web \ 
+  --volume $PWD:/usr/src/app asciidoctor-web-pdf \ 
   asciidoctor-web-pdf maven-security-cheat-sheet.adoc --template-require ./snyk/template.js
 ```
 
 The `--volume` option will mount your local copy of the Asciidoctor Web PDF repository on the container.
+
 ## Get started
 
 Asciidoctor Web PDF provides a standard document layout.

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ $ yarn global add @asciidoctor/core asciidoctor-pdf
 
 Currently, the Docker image is not yet published on [Docker Hub](https://hub.docker.com/).
 
-Therefore, you can build your own custom docker image.
+Therefore, you will need to build the Docker image from the Dockerfile.
 
 The base image is from the official [puppeteer](https://github.com/puppeteer/puppeteer/pkgs/container/puppeteer), which contains puppeteer and google-chrome for pdf generation.
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ $ yarn global add @asciidoctor/core asciidoctor-pdf
 
 ### Using Docker
 
-Currently, there is no public image yet pushed in a public docker registry.
+Currently, the Docker image is not yet published on [Docker Hub](https://hub.docker.com/).
 
 Therefore, you can build your own custom docker image.
 

--- a/README.md
+++ b/README.md
@@ -220,12 +220,24 @@ CLI version 3.5.0
 If you want to render the cheatsheet example, move to the root of this repository and type:
 
 ```bash
-docker run --rm \ 
-  --volume $PWD:/usr/src/app asciidoctor-web-pdf \ 
-  asciidoctor-web-pdf maven-security-cheat-sheet.adoc --template-require ./snyk/template.js
+cd examples/cheat-sheet
+docker run -i --rm \
+  --volume=$PWD:"/usr/src/app" \
+  -u $(id -u ${USER}):$(id -g ${USER}) \
+  asciidoctor-web-pdf:latest asciidoctor-web-pdf \
+  --template-require ./snyk/template.js maven-security-cheat-sheet.adoc 
 ```
 
 The `--volume` option will mount your local copy of the Asciidoctor Web PDF repository on the container.
+Since it is a non-root user we have to map our user to `asciidoctor` user in the container.
+
+You can also use `stdin` and `stdout` without the need of volumes.
+
+```bash
+cd examples/document
+cat document.adoc | docker run -i --rm -a stdin -a stdout -a stderr asciidoctor-web-pdf:latest \
+ asciidoctor-web-pdf - > doc.pdf
+```
 
 ## Get started
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ cd docker
 docker build . -t adoc2web
 ```
 
-Check installation in docker container.
+Verify that the Docker image is working by running:
 
 ```bash
 docker run --rm adoc2web asciidoctor-web-pdf --version

--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ docker run --rm \
   asciidoctor-web-pdf maven-security-cheat-sheet.adoc --template-require ./snyk/template.js
 ```
 
+The `--volume` option will mount your local copy of the Asciidoctor Web PDF repository on the container.
 ## Get started
 
 Asciidoctor Web PDF provides a standard document layout.

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Therefore, you will need to build the Docker image from the Dockerfile.
 
 The base image is from the official [puppeteer repository] (https://github.com/puppeteer/puppeteer/pkgs/container/puppeteer), which contains puppeteer and Google Chrome for PDF generation.
 
-To build the docker image. The target image name in this example is `adoc2web`.
+To build the Docker image, clone this repository and type the following commands: 
 
 ```bash
 cd docker

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Currently, the Docker image is not yet published on [Docker Hub](https://hub.doc
 
 Therefore, you will need to build the Docker image from the Dockerfile.
 
-The base image is from the official [puppeteer](https://github.com/puppeteer/puppeteer/pkgs/container/puppeteer), which contains puppeteer and google-chrome for pdf generation.
+The base image is from the official [puppeteer repository] (https://github.com/puppeteer/puppeteer/pkgs/container/puppeteer), which contains puppeteer and Google Chrome for PDF generation.
 
 To build the docker image. The target image name in this example is `adoc2web`.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM ghcr.io/puppeteer/puppeteer:17.0.0
+# LABEL org.opencontainers.image.authors="Mogztter#Guillaume Grossetie"
+LABEL version="17.0.0"
+LABEL description="This docker image contains \
+asciidoctor-web-pdf to generate websites and pdf from asciidoc(tor)."
+
+ENV PUPPETEER_SKIP_DOWNLOAD=true \
+    PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
+
+USER root
+WORKDIR /usr/src/app
+
+RUN npm install -g @asciidoctor/core asciidoctor-pdf --save-dev

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,18 +1,41 @@
-FROM ghcr.io/puppeteer/puppeteer:17.0.0
+FROM node:16
 # LABEL org.opencontainers.image.authors="Mogztter#Guillaume Grossetie"
-LABEL version="17.0.0"
+LABEL version="15.4.0"
 LABEL description="This docker image contains \
 asciidoctor-web-pdf to generate websites and pdf from asciidoc(tor)."
+
+ENV NODE_ENV="production"
+
+# Install latest chrome dev package and fonts to support major charsets (Chinese, Japanese, Arabic, Hebrew, Thai and a few others)
+# Note: this installs the necessary libs to make the bundled version of Chromium that Puppeteer
+# installs, work.
+RUN apt-get update \
+    && apt-get install -y wget gnupg \
+    && wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
+    && sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list' \
+    && apt-get update \
+    && apt-get install -y google-chrome-stable fonts-ipafont-gothic fonts-wqy-zenhei fonts-thai-tlwg fonts-khmeros fonts-kacst fonts-freefont-ttf libxss1 \
+      --no-install-recommends \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /home/pptruser
+
+# Install puppeteer into /home/pptruser/node_modules.
+RUN yarn add "puppeteer@15.4.0" \
+    # Add user so we don't need --no-sandbox.
+    # same layer as npm install to keep re-chowned files from using up several hundred MBs more space
+    && groupadd -r pptruser && useradd -r -g pptruser -G audio,video pptruser \
+    && mkdir -p /home/pptruser/Downloads \
+    && chown -R pptruser:pptruser /home/pptruser \
+    && (node -e "require('child_process').execSync(require('puppeteer').executablePath() + ' --credits', {stdio: 'inherit'})" > THIRD_PARTY_NOTICES)
 
 ENV PUPPETEER_SKIP_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
 
-ENV NODE_ENV="production"
-
-USER root
 WORKDIR /usr/src/app
 
-RUN npm install -g @asciidoctor/core asciidoctor-pdf --save-dev
+RUN yarn global add @asciidoctor/core asciidoctor-pdf \
+    && groupadd -r asciidoctor && useradd -r -g asciidoctor -G audio,video asciidoctor \
+    && chown -R asciidoctor:asciidoctor /usr/src/app
 
-# Run everything after as non-privileged user.
-USER pptruser
+USER asciidoctor

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,12 @@ asciidoctor-web-pdf to generate websites and pdf from asciidoc(tor)."
 ENV PUPPETEER_SKIP_DOWNLOAD=true \
     PUPPETEER_EXECUTABLE_PATH=/usr/bin/google-chrome
 
+ENV NODE_ENV="production"
+
 USER root
 WORKDIR /usr/src/app
 
 RUN npm install -g @asciidoctor/core asciidoctor-pdf --save-dev
+
+# Run everything after as non-privileged user.
+USER pptruser

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:16
 # LABEL org.opencontainers.image.authors="Mogztter#Guillaume Grossetie"
-LABEL version="15.4.0"
+# LABEL version=""
 LABEL description="This docker image contains \
 asciidoctor-web-pdf to generate websites and pdf from asciidoc(tor)."
 


### PR DESCRIPTION
Based on issue #306 

https://github.com/Mogztter/asciidoctor-web-pdf/issues/306 

I have added in the README the docker usage and a straightforward Dockerfile.

Everything works out of the box. As enhancement I propose to push it into the public docker registry or use the public github docker registry.