### PR TITLE
Replace mocha/chai/dirty-chai/sinon with Node.js built-in test runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,17 +52,17 @@ jobs:
       run: |
         npm run build
     - name: Upload Windows artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: win-binary
         path: build/asciidoctor-web-pdf-win.zip
     - name: Upload macOS artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mac-binary
         path: build/asciidoctor-web-pdf-mac.zip
     - name: Upload Linux artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: linux-binary
         path: build/asciidoctor-web-pdf-linux.zip
@@ -70,7 +70,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: linux-binary
       - name: Unzip
@@ -87,7 +87,7 @@ jobs:
     needs: build
     runs-on: macos-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: mac-binary
       - name: Unzip
@@ -104,7 +104,7 @@ jobs:
     needs: build
     runs-on: windows-latest
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: win-binary
       - name: Unzip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,31 +10,20 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-        node-version:
-          - 16
-          - 18
-        include:
-          - os: ubuntu-latest
-            node-version: '16'
-            primary: true
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.package_info.outputs.version }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
     - name: Current version
       id: package_info
       run: |
         VERSION=$(node -e 'console.log(require("./package.json").version)')
         echo "::set-output name=version::v$VERSION"
-    - name: Set up Node ${{ matrix.node-version }}
-      uses: actions/setup-node@v3
+    - name: Set up Node 24
+      uses: actions/setup-node@v6
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version: 24
     # libgbm-dev is required by Puppeteer 3+
     - name: Install system dependencies
       run: |
@@ -62,25 +51,21 @@ jobs:
     - name: Build binary
       run: |
         npm run build
-      if: matrix.primary
     - name: Upload Windows artifact
       uses: actions/upload-artifact@v3
       with:
         name: win-binary
         path: build/asciidoctor-web-pdf-win.zip
-      if: matrix.primary
     - name: Upload macOS artifact
       uses: actions/upload-artifact@v3
       with:
         name: mac-binary
         path: build/asciidoctor-web-pdf-mac.zip
-      if: matrix.primary
     - name: Upload Linux artifact
       uses: actions/upload-artifact@v3
       with:
         name: linux-binary
         path: build/asciidoctor-web-pdf-linux.zip
-      if: matrix.primary
   test-linux:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,10 +9,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
       # libgbm-dev is required by Puppeteer 3+
       - name: Install system dependencies
         run: |
@@ -30,10 +30,10 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
       # libgbm-dev is required by Puppeteer 3+
       - name: Install system dependencies
         run: |
@@ -93,10 +93,10 @@ jobs:
   publish_dockerhub:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.3.0
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
       - name: Install dependencies
         run: |
           npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Package the Node.js project into a single binary
-FROM --platform=${TARGETPLATFORM:-linux/amd64} node:16.17.0-alpine3.16 as builder
+FROM --platform=${TARGETPLATFORM:-linux/amd64} node:16.17.0-alpine3.16 AS builder
 
 # Workaround: https://github.com/nodejs/docker-node/issues/813#issuecomment-407339011
 # Error: could not get uid/gid

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -118,7 +118,7 @@ class PdfInvoker extends Invoker {
 }
 
 module.exports = {
-  PdfOptions: PdfOptions,
-  PdfInvoker: PdfInvoker,
-  processor: processor
+  PdfOptions,
+  PdfInvoker,
+  processor
 }

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -165,6 +165,6 @@ function getTemporaryHtmlFile (inputFile, options) {
 }
 
 module.exports = {
-  convert: convert,
-  registerTemplateConverter: registerTemplateConverter
+  convert,
+  registerTemplateConverter
 }

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -39,5 +39,5 @@ const addMetadata = async (pdfDoc, doc) => {
 }
 
 module.exports = {
-  addMetadata: addMetadata
+  addMetadata
 }

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -19,7 +19,7 @@ function getOutline (node, depth) {
     .map(section => {
       const title = sanitize(section.getTitle())
       return {
-        title: title,
+        title,
         destination: section.getId(),
         children: getOutline(section, depth - 1)
       }
@@ -111,5 +111,5 @@ async function addOutline (pdfDoc, doc) {
 }
 
 module.exports = {
-  addOutline: addOutline
+  addOutline
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,21 +31,17 @@
       "devDependencies": {
         "@asciidoctor/core": "~2.2",
         "archiver": "~5.3.0",
-        "chai": "~4.3",
         "cheerio": "~1.0.0-rc.3",
-        "dirty-chai": "~2.0",
         "libnpmpublish": "~4.0",
-        "mocha": "~10.2.0",
         "nunjucks": "~3.2",
         "pacote": "~12.0",
         "pixelmatch": "~5.3.0",
         "pkg": "~5.8",
         "rimraf": "~4.1.0",
-        "sinon": "~15.0.0",
         "standard": "~17.0.0"
       },
       "engines": {
-        "node": ">=16",
+        "node": ">=18",
         "npm": ">=8.0.0"
       },
       "peerDependencies": {
@@ -637,41 +633,6 @@
         "pako": "^1.0.10"
       }
     },
-    "node_modules/@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/fake-timers": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0"
-      }
-    },
-    "node_modules/@sinonjs/samsam": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
-      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "node_modules/@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
-    },
     "node_modules/@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -795,6 +756,7 @@
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1044,15 +1006,6 @@
         "node": "*"
       }
     },
-    "node_modules/assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -1158,12 +1111,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
-    },
     "node_modules/buffer": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
@@ -1267,36 +1214,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
-      "dev": true,
-      "dependencies": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1323,15 +1240,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/cheerio": {
@@ -1630,18 +1538,6 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "node_modules/decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -1652,18 +1548,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "dependencies": {
-        "type-detect": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.12"
       }
     },
     "node_modules/deep-extend": {
@@ -1729,15 +1613,6 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz",
       "integrity": "sha512-OKvTvu9n3swmgYshvsyVHYX0+aPzCoYUnyXUacfQMmFtBtBKewV/gT4I9jkAbpTqtTi2E4S9MXLlvzBDUlqg0Q=="
     },
-    "node_modules/diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -1748,15 +1623,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dirty-chai": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
-      "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
-      "dev": true,
-      "peerDependencies": {
-        "chai": ">=2.2.1 <5"
       }
     },
     "node_modules/doctrine": {
@@ -2696,15 +2562,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true,
-      "bin": {
-        "flat": "cli.js"
-      }
-    },
     "node_modules/flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -2907,15 +2764,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3170,15 +3018,6 @@
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "dev": true
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "dev": true,
-      "bin": {
-        "he": "bin/he"
-      }
     },
     "node_modules/hosted-git-info": {
       "version": "4.1.0",
@@ -3580,15 +3419,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -3666,18 +3496,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -3689,12 +3507,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3810,12 +3622,6 @@
       "engines": {
         "node": ">=4.0"
       }
-    },
-    "node_modules/just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
     },
     "node_modules/lazystream": {
       "version": "1.0.1",
@@ -3934,12 +3740,6 @@
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true
     },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
-    },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -3965,22 +3765,6 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
-    "node_modules/log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "dependencies": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3991,15 +3775,6 @@
       },
       "bin": {
         "loose-envify": "cli.js"
-      }
-    },
-    "node_modules/loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
-      "dev": true,
-      "dependencies": {
-        "get-func-name": "^2.0.0"
       }
     },
     "node_modules/lru-cache": {
@@ -4219,117 +3994,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
-    "node_modules/mocha": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
-      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
-      "dev": true,
-      "dependencies": {
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "bin": {
-        "_mocha": "bin/_mocha",
-        "mocha": "bin/mocha.js"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/mochajs"
-      }
-    },
-    "node_modules/mocha/node_modules/glob": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/mocha/node_modules/glob/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-      "dev": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/mocha/node_modules/minimatch/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/mocha/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dev": true,
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -4360,18 +4024,6 @@
         "readable-stream": "^3.6.0"
       }
     },
-    "node_modules/nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-      "dev": true,
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
     "node_modules/napi-build-utils": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
@@ -4397,19 +4049,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "node_modules/nise": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
-      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
     },
     "node_modules/node-abi": {
       "version": "2.30.1",
@@ -5273,15 +4912,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "node_modules/path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "dependencies": {
-        "isarray": "0.0.1"
-      }
-    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -5289,15 +4919,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/pdf-lib": {
@@ -5931,15 +5552,6 @@
         }
       ]
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -6226,15 +5838,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "dev": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "node_modules/set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -6311,36 +5914,6 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
-      }
-    },
-    "node_modules/sinon": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
-      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
-      "dev": true,
-      "dependencies": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "10.0.2",
-        "@sinonjs/samsam": "^7.0.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.2",
-        "supports-color": "^7.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/sinon"
-      }
-    },
-    "node_modules/sinon/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/slash": {
@@ -6935,21 +6508,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
-      }
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -7131,15 +6689,6 @@
       },
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true,
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -7347,12 +6896,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/workerpool": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-      "dev": true
-    },
     "node_modules/wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -7438,21 +6981,6 @@
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
       "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "dependencies": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      },
       "engines": {
         "node": ">=10"
       }
@@ -7977,41 +7505,6 @@
         "pako": "^1.0.10"
       }
     },
-    "@sinonjs/commons": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
-      "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
-      "dev": true,
-      "requires": {
-        "type-detect": "4.0.8"
-      }
-    },
-    "@sinonjs/fake-timers": {
-      "version": "10.0.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.0.2.tgz",
-      "integrity": "sha512-SwUDyjWnah1AaNl7kxsa7cfLhlTYoiyhDAIgyh+El30YvXs/o7OLXpYH88Zdhyx9JExKrmHDJ+10bwIcY80Jmw==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0"
-      }
-    },
-    "@sinonjs/samsam": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-7.0.1.tgz",
-      "integrity": "sha512-zsAk2Jkiq89mhZovB2LLOdTCxJF4hqqTToGP0ASWlhp4I1hqOjcfmZGafXntCN7MDC6yySH0mFHrYtHceOeLmw==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "lodash.get": "^4.4.2",
-        "type-detect": "^4.0.8"
-      }
-    },
-    "@sinonjs/text-encoding": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
-      "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
-      "dev": true
-    },
     "@tootallnate/once": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
@@ -8110,7 +7603,8 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
       "integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "ansi-regex": {
       "version": "5.0.1",
@@ -8313,12 +7807,6 @@
         }
       }
     },
-    "assertion-error": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-      "dev": true
-    },
     "astral-regex": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
@@ -8391,12 +7879,6 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
-    },
-    "browser-stdout": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
-      "dev": true
     },
     "buffer": {
       "version": "5.7.1",
@@ -8471,27 +7953,6 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
       "dev": true
     },
-    "camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true
-    },
-    "chai": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.6.tgz",
-      "integrity": "sha512-bbcp3YfHCUzMOvKqsztczerVgBKSsEijCySNlHHbX3VG1nskvqjz5Rfso1gGwD6w6oOV3eI60pKuMOV5MV7p3Q==",
-      "dev": true,
-      "requires": {
-        "assertion-error": "^1.1.0",
-        "check-error": "^1.0.2",
-        "deep-eql": "^3.0.1",
-        "get-func-name": "^2.0.0",
-        "loupe": "^2.3.1",
-        "pathval": "^1.1.1",
-        "type-detect": "^4.0.5"
-      }
-    },
     "chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -8512,12 +7973,6 @@
           }
         }
       }
-    },
-    "check-error": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
-      "integrity": "sha512-BrgHpW9NURQgzoNyjfq0Wu6VFO6D7IZEmJNdtgNqpzGG8RuNFHt2jQxWlAs4HMe119chBnv+34syEZtc6IhLtA==",
-      "dev": true
     },
     "cheerio": {
       "version": "1.0.0-rc.12",
@@ -8742,12 +8197,6 @@
         }
       }
     },
-    "decamelize": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
-      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
-      "dev": true
-    },
     "decompress-response": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
@@ -8755,15 +8204,6 @@
       "dev": true,
       "requires": {
         "mimic-response": "^2.0.0"
-      }
-    },
-    "deep-eql": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
-      "dev": true,
-      "requires": {
-        "type-detect": "^4.0.0"
       }
     },
     "deep-extend": {
@@ -8811,12 +8251,6 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1011705.tgz",
       "integrity": "sha512-OKvTvu9n3swmgYshvsyVHYX0+aPzCoYUnyXUacfQMmFtBtBKewV/gT4I9jkAbpTqtTi2E4S9MXLlvzBDUlqg0Q=="
     },
-    "diff": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-      "dev": true
-    },
     "dir-glob": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
@@ -8825,13 +8259,6 @@
       "requires": {
         "path-type": "^4.0.0"
       }
-    },
-    "dirty-chai": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz",
-      "integrity": "sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==",
-      "dev": true,
-      "requires": {}
     },
     "doctrine": {
       "version": "3.0.0",
@@ -9564,12 +8991,6 @@
         "path-exists": "^4.0.0"
       }
     },
-    "flat": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
-      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
-      "dev": true
-    },
     "flat-cache": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
@@ -9741,12 +9162,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
     },
-    "get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
-      "dev": true
-    },
     "get-intrinsic": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.3.tgz",
@@ -9917,12 +9332,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
-      "dev": true
-    },
-    "he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
     "hosted-git-info": {
@@ -10208,12 +9617,6 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
-    "is-plain-obj": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-      "dev": true
-    },
     "is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -10264,12 +9667,6 @@
         "has-tostringtag": "^1.0.0"
       }
     },
-    "is-unicode-supported": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
-      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
-      "dev": true
-    },
     "is-weakref": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
@@ -10278,12 +9675,6 @@
       "requires": {
         "call-bind": "^1.0.2"
       }
-    },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
@@ -10375,12 +9766,6 @@
         "array-includes": "^3.1.5",
         "object.assign": "^4.1.3"
       }
-    },
-    "just-extend": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.2.1.tgz",
-      "integrity": "sha512-g3UB796vUFIY90VIv/WX3L2c8CS2MdWUww3CNrYmqza1Fg0DURc2K/O4YrnklBdQarSJ/y8JnJYDGc+1iumQjg==",
-      "dev": true
     },
     "lazystream": {
       "version": "1.0.1",
@@ -10486,12 +9871,6 @@
       "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true
     },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
-    },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
@@ -10517,16 +9896,6 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
-    "log-symbols": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
-      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
-      "dev": true,
-      "requires": {
-        "chalk": "^4.1.0",
-        "is-unicode-supported": "^0.1.0"
-      }
-    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -10534,15 +9903,6 @@
       "dev": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "loupe": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
-      "integrity": "sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==",
-      "dev": true,
-      "requires": {
-        "get-func-name": "^2.0.0"
       }
     },
     "lru-cache": {
@@ -10712,97 +10072,6 @@
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
     },
-    "mocha": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.2.0.tgz",
-      "integrity": "sha512-IDY7fl/BecMwFHzoqF2sg/SHHANeBoMMXFlS9r0OXKDssYE1M5O43wUY/9BVPeIvfH2zmEbBfseqN9gBQZzXkg==",
-      "dev": true,
-      "requires": {
-        "ansi-colors": "4.1.1",
-        "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
-        "debug": "4.3.4",
-        "diff": "5.0.0",
-        "escape-string-regexp": "4.0.0",
-        "find-up": "5.0.0",
-        "glob": "7.2.0",
-        "he": "1.2.0",
-        "js-yaml": "4.1.0",
-        "log-symbols": "4.1.0",
-        "minimatch": "5.0.1",
-        "ms": "2.1.3",
-        "nanoid": "3.3.3",
-        "serialize-javascript": "6.0.0",
-        "strip-json-comments": "3.1.1",
-        "supports-color": "8.1.1",
-        "workerpool": "6.2.1",
-        "yargs": "16.2.0",
-        "yargs-parser": "20.2.4",
-        "yargs-unparser": "2.0.0"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
-          "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          },
-          "dependencies": {
-            "minimatch": {
-              "version": "3.1.2",
-              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-              "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-              "dev": true,
-              "requires": {
-                "brace-expansion": "^1.1.7"
-              }
-            }
-          }
-        },
-        "minimatch": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
-          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
-          "dev": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          },
-          "dependencies": {
-            "brace-expansion": {
-              "version": "2.0.1",
-              "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-              "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-              "dev": true,
-              "requires": {
-                "balanced-match": "^1.0.0"
-              }
-            }
-          }
-        },
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "dev": true,
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        }
-      }
-    },
     "ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -10818,12 +10087,6 @@
         "once": "^1.4.0",
         "readable-stream": "^3.6.0"
       }
-    },
-    "nanoid": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
-      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
-      "dev": true
     },
     "napi-build-utils": {
       "version": "1.0.2",
@@ -10847,19 +10110,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ=="
-    },
-    "nise": {
-      "version": "5.1.4",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.4.tgz",
-      "integrity": "sha512-8+Ib8rRJ4L0o3kfmyVCL7gzrohyDe0cMFTBa2d364yIrEGMEoetznKJx899YxjybU6bL9SQkYPSBBs1gyYs8Xg==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "^10.0.2",
-        "@sinonjs/text-encoding": "^0.7.1",
-        "just-extend": "^4.0.2",
-        "path-to-regexp": "^1.7.0"
-      }
     },
     "node-abi": {
       "version": "2.30.1",
@@ -11508,25 +10758,10 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "path-to-regexp": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
-      "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
-      "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      }
-    },
     "path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true
-    },
-    "pathval": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
       "dev": true
     },
     "pdf-lib": {
@@ -12026,15 +11261,6 @@
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
     },
-    "randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -12227,15 +11453,6 @@
         "lru-cache": "^6.0.0"
       }
     },
-    "serialize-javascript": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
-      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
-      "dev": true,
-      "requires": {
-        "randombytes": "^2.1.0"
-      }
-    },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
@@ -12289,31 +11506,6 @@
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
-      }
-    },
-    "sinon": {
-      "version": "15.0.1",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-15.0.1.tgz",
-      "integrity": "sha512-PZXKc08f/wcA/BMRGBze2Wmw50CWPiAH3E21EOi4B49vJ616vW4DQh4fQrqsYox2aNR/N3kCqLuB0PwwOucQrg==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/commons": "^2.0.0",
-        "@sinonjs/fake-timers": "10.0.2",
-        "@sinonjs/samsam": "^7.0.1",
-        "diff": "^5.0.0",
-        "nise": "^5.1.2",
-        "supports-color": "^7.2.0"
-      },
-      "dependencies": {
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
       }
     },
     "slash": {
@@ -12728,15 +11920,6 @@
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
     },
-    "supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
-    },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -12892,12 +12075,6 @@
       "requires": {
         "prelude-ls": "^1.2.1"
       }
-    },
-    "type-detect": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-      "dev": true
     },
     "type-fest": {
       "version": "0.8.1",
@@ -13071,12 +12248,6 @@
       "integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
       "dev": true
     },
-    "workerpool": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
-      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
-      "dev": true
-    },
     "wrap-ansi": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
@@ -13150,18 +12321,6 @@
       "version": "20.2.4",
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
       "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
-    },
-    "yargs-unparser": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
-      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
-      "dev": true,
-      "requires": {
-        "camelcase": "^6.0.0",
-        "decamelize": "^4.0.0",
-        "flat": "^5.0.2",
-        "is-plain-obj": "^2.1.0"
-      }
     },
     "yauzl": {
       "version": "2.10.0",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0-alpha.16",
   "description": "A PDF converter for AsciiDoc based on web technologies",
   "engines": {
-    "node": ">=16",
+    "node": ">=18",
     "npm": ">=8.0.0"
   },
   "bin": {
@@ -27,7 +27,7 @@
     "build": "node tasks/prepare-binaries.js",
     "test": "npm run test:smoke && npm run test:js",
     "test:smoke": "./bin/asciidoctor-web-pdf --version",
-    "test:js": "mocha test/**_test.js",
+    "test:js": "node --test --test-timeout=30000 test/*_test.js",
     "lint": "standard lib/**.js test/**.js tasks/**js",
     "publish": "node tasks/publish.js",
     "test:update-linux-reference": "docker build -f test/Dockerfile -t asciidoctor/web-pdf-test . && docker run --name asciidoctorwebpdftest asciidoctor/web-pdf-test:latest; docker cp asciidoctorwebpdftest:/app/test/output/. ./test/reference/linux/ && docker rm asciidoctorwebpdftest"
@@ -66,17 +66,13 @@
   "devDependencies": {
     "@asciidoctor/core": "~2.2",
     "archiver": "~5.3.0",
-    "chai": "~4.3",
     "cheerio": "~1.0.0-rc.3",
-    "dirty-chai": "~2.0",
     "libnpmpublish": "~4.0",
-    "mocha": "~10.2.0",
     "nunjucks": "~3.2",
     "pacote": "~12.0",
     "pixelmatch": "~5.3.0",
     "pkg": "~5.8",
     "rimraf": "~4.1.0",
-    "sinon": "~15.0.0",
     "standard": "~17.0.0"
   },
   "peerDependencies": {

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -1,8 +1,5 @@
-/* global it, describe */
-const chai = require('chai')
-const expect = chai.expect
-const dirtyChai = require('dirty-chai')
-chai.use(dirtyChai)
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
 
 const { PdfOptions, PdfInvoker, processor } = require('../lib/cli.js')
 
@@ -11,10 +8,10 @@ describe('CLI', () => {
     const options = new PdfOptions().parse(['node', 'asciidoctor-pdf', 'doc.adoc'])
     const pdfInvoker = new PdfInvoker(options)
     const attributes = pdfInvoker.options.options.attributes
-    expect(attributes).to.include('env-web-pdf')
-    expect(attributes).to.include('env=web-pdf')
+    assert.ok(attributes.includes('env-web-pdf'))
+    assert.ok(attributes.includes('env=web-pdf'))
     const html = processor.convert('{env}', Object.assign({}, pdfInvoker.options.options, { standalone: false }))
-    expect(html).to.equal(`<div class="paragraph">
+    assert.strictEqual(html, `<div class="paragraph">
 <p>web-pdf</p>
 </div>`)
   })
@@ -22,11 +19,11 @@ describe('CLI', () => {
     const options = new PdfOptions().parse(['node', 'asciidoctor-pdf', 'doc.adoc', '-a', 'env=pdf'])
     const pdfInvoker = new PdfInvoker(options)
     const attributes = pdfInvoker.options.options.attributes
-    expect(attributes).to.include('env-web-pdf')
-    expect(attributes).to.include('env=web-pdf')
-    expect(attributes).to.include('env=pdf')
+    assert.ok(attributes.includes('env-web-pdf'))
+    assert.ok(attributes.includes('env=web-pdf'))
+    assert.ok(attributes.includes('env=pdf'))
     const html = processor.convert('{env}', Object.assign({}, pdfInvoker.options.options, { standalone: false }))
-    expect(html).to.equal(`<div class="paragraph">
+    assert.strictEqual(html, `<div class="paragraph">
 <p>pdf</p>
 </div>`)
   })

--- a/test/docker-smoke-test.md5sum
+++ b/test/docker-smoke-test.md5sum
@@ -1,1 +1,1 @@
-d704d54146b1571faa9379e2b232ecd1  test/output/docker-smoke-test.pdf
+2958c9ab1003172e55be5085d3c2522f  test/output/docker-smoke-test.pdf

--- a/test/document_convert_test.js
+++ b/test/document_convert_test.js
@@ -1,10 +1,7 @@
-/* global it, describe */
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
 const cheerio = require('cheerio')
 const ospath = require('path')
-const chai = require('chai')
-const expect = chai.expect
-const dirtyChai = require('dirty-chai')
-chai.use(dirtyChai)
 
 const asciidoctor = require('@asciidoctor/core')()
 const DocumentConverter = require('../lib/document/document-converter')
@@ -26,7 +23,7 @@ Guillaume Grossetie
 
 == Section`, { backend: 'custom-web-pdf' })
     const $ = cheerio.load(doc.convert({ header_footer: true }))
-    expect($('h1').text()).to.equal('Static title')
+    assert.strictEqual($('h1').text(), 'Static title')
   })
 
   describe('Docinfo', () => {
@@ -39,8 +36,8 @@ Guillaume Grossetie
         to_file: false,
         attributes: { docinfo: 'shared' }
       }))
-      expect($('head > meta[name="keywords"]').attr('content')).to.equal('journalism, press')
-      expect($('head > script[src="debug.js"]').length).to.equal(1)
+      assert.strictEqual($('head > meta[name="keywords"]').attr('content'), 'journalism, press')
+      assert.strictEqual($('head > script[src="debug.js"]').length, 1)
     })
     it('should include private (footer) docinfo', () => {
       asciidoctor.ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
@@ -51,7 +48,7 @@ Guillaume Grossetie
         to_file: false,
         attributes: { docinfo: 'private-footer' }
       }))
-      expect($('footer').text()).to.equal('This is the end.')
+      assert.strictEqual($('footer').text(), 'This is the end.')
     })
     it('should include private (running) docinfo', () => {
       asciidoctor.ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
@@ -62,7 +59,7 @@ Guillaume Grossetie
         to_file: false,
         attributes: { docinfo: 'private-running' }
       }))
-      expect($('body > .contact-us').length).to.equal(1)
+      assert.strictEqual($('body > .contact-us').length, 1)
     })
   })
 })

--- a/test/helper.js
+++ b/test/helper.js
@@ -33,7 +33,7 @@ function toVisuallyMatch (referenceFilename, actualPath) {
   }
 
   if (!fs.existsSync(actualPath)) {
-    return false
+    throw new Error(`File does not exist: ${actualPath}`)
   }
   const imagesOutputDir = outputFile('visual-comparison-workdir')
   if (!fs.existsSync(imagesOutputDir)) {
@@ -74,25 +74,8 @@ function toVisuallyMatch (referenceFilename, actualPath) {
     if (typeof process.env.DEBUG === 'undefined') {
       tmpFiles.forEach((file) => fs.unlinkSync(file))
     }
-    return pixels
-  } else {
-    return pixels
   }
+  return pixels
 }
 
-module.exports = (chai) => {
-  chai.use(function (_chai, _) {
-    _chai.Assertion.addMethod('visuallyIdentical', function (reference) {
-      const obj = this._obj
-      const result = toVisuallyMatch(reference, obj)
-      const objRelativePath = ospath.relative(__dirname, obj)
-      this.assert(
-        result === 0
-        , `expected ${objRelativePath} to be visually identical to reference/${reference} but has ${result} pixels difference`
-        , `expected ${objRelativePath} to not be visually identical to reference/${reference} but has 0 pixel difference`
-        , 0
-        , result
-      )
-    })
-  })
-}
+module.exports = { toVisuallyMatch }

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -1,9 +1,6 @@
-/* global it, describe */
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
 const { PDFDocument, PDFName, PDFHexString } = require('pdf-lib')
-const chai = require('chai')
-const expect = chai.expect
-const dirtyChai = require('dirty-chai')
-chai.use(dirtyChai)
 
 const asciidoctor = require('@asciidoctor/core')()
 const { addMetadata } = require('../lib/metadata.js')
@@ -24,13 +21,13 @@ const decodePDFHexValue = (value) => {
   return str
 }
 
-const expectEqual = (pdf, metadataKey, expectedValue) => {
+const assertMetadataEqual = (pdf, metadataKey, expectedValue) => {
   const metadata = pdf.context.lookup(pdf.context.trailerInfo.Info)
   const pdfValue = metadata.get(PDFName.of(metadataKey))
   if (pdfValue instanceof PDFHexString) {
-    expect(decodePDFHexValue(pdfValue.value)).to.equal(expectedValue, metadataKey)
+    assert.strictEqual(decodePDFHexValue(pdfValue.value), expectedValue, metadataKey)
   } else {
-    expect(pdfValue.value).to.equal(expectedValue, metadataKey)
+    assert.strictEqual(pdfValue.value, expectedValue, metadataKey)
   }
 }
 
@@ -49,19 +46,19 @@ v1.0, 2019-11-05
 
 content`)
 
-    expectEqual(pdfWithMetadata, 'Title', 'The Dangerous and Thrilling Documentation Chronicles')
-    expectEqual(pdfWithMetadata, 'Author', 'Guillaume Grossetie')
-    expectEqual(pdfWithMetadata, 'Subject', '')
-    expectEqual(pdfWithMetadata, 'Keywords', 'pdf asciidoctor doc')
-    expectEqual(pdfWithMetadata, 'Producer', 'Guillaume Grossetie')
-    expectEqual(pdfWithMetadata, 'Creator', `Asciidoctor Web PDF ${pkgVersion}`)
+    assertMetadataEqual(pdfWithMetadata, 'Title', 'The Dangerous and Thrilling Documentation Chronicles')
+    assertMetadataEqual(pdfWithMetadata, 'Author', 'Guillaume Grossetie')
+    assertMetadataEqual(pdfWithMetadata, 'Subject', '')
+    assertMetadataEqual(pdfWithMetadata, 'Keywords', 'pdf asciidoctor doc')
+    assertMetadataEqual(pdfWithMetadata, 'Producer', 'Guillaume Grossetie')
+    assertMetadataEqual(pdfWithMetadata, 'Creator', `Asciidoctor Web PDF ${pkgVersion}`)
   })
 
   it('should add epoch unix at start date if reproducible attribute is set', async () => {
     const pdfWithMetadata = await toPdfWithMetadata('', { attributes: { reproducible: true } })
 
-    expectEqual(pdfWithMetadata, 'CreationDate', 'D:19700101000000Z')
-    expectEqual(pdfWithMetadata, 'ModDate', 'D:19700101000000Z')
+    assertMetadataEqual(pdfWithMetadata, 'CreationDate', 'D:19700101000000Z')
+    assertMetadataEqual(pdfWithMetadata, 'ModDate', 'D:19700101000000Z')
   })
 
   it('should set Producer field to value of publisher attribute if set', async () => {
@@ -71,8 +68,8 @@ Author Name
 
 content`)
 
-    expectEqual(pdfWithMetadata, 'Author', 'Author Name')
-    expectEqual(pdfWithMetadata, 'Producer', 'Big Cheese')
+    assertMetadataEqual(pdfWithMetadata, 'Author', 'Author Name')
+    assertMetadataEqual(pdfWithMetadata, 'Producer', 'Big Cheese')
   })
 
   it('should set Author and Producer field to value of author attribute if set', async () => {
@@ -81,16 +78,16 @@ content`)
 
 content`)
 
-    expectEqual(pdfWithMetadata, 'Producer', 'Author Name')
-    expectEqual(pdfWithMetadata, 'Author', 'Author Name')
+    assertMetadataEqual(pdfWithMetadata, 'Producer', 'Author Name')
+    assertMetadataEqual(pdfWithMetadata, 'Author', 'Author Name')
   })
 
   it('should set Producer field to value of Creator field by default', async () => {
     const pdfWithMetadata = await toPdfWithMetadata('hello')
 
     const creator = `Asciidoctor Web PDF ${pkgVersion}`
-    expectEqual(pdfWithMetadata, 'Creator', creator)
-    expectEqual(pdfWithMetadata, 'Producer', creator)
+    assertMetadataEqual(pdfWithMetadata, 'Creator', creator)
+    assertMetadataEqual(pdfWithMetadata, 'Producer', creator)
   })
 
   it('should set Subject field to value of subject attribute if set', async () => {
@@ -99,7 +96,7 @@ content`)
 
 content`)
 
-    expectEqual(pdfWithMetadata, 'Subject', 'Cooking')
+    assertMetadataEqual(pdfWithMetadata, 'Subject', 'Cooking')
   })
 
   it('should set Lang field with the default language (en)', async () => {
@@ -107,7 +104,7 @@ content`)
 
 content`)
 
-    expect(pdfWithMetadata.catalog.get(PDFName.of('Lang')).value).to.equal('en')
+    assert.strictEqual(pdfWithMetadata.catalog.get(PDFName.of('Lang')).value, 'en')
   })
 
   it('should set Lang field to value of lang attribute', async () => {
@@ -116,7 +113,7 @@ content`)
 
 content`)
 
-    expect(pdfWithMetadata.catalog.get(PDFName.of('Lang')).value).to.equal('de')
+    assert.strictEqual(pdfWithMetadata.catalog.get(PDFName.of('Lang')).value, 'de')
   })
 
   it('should not set Lang field when nolang attribute is set', async () => {
@@ -125,6 +122,6 @@ content`)
 
 content`)
 
-    expect(pdfWithMetadata.catalog.get(PDFName.of('Lang'))).to.be.undefined()
+    assert.strictEqual(pdfWithMetadata.catalog.get(PDFName.of('Lang')), undefined)
   })
 })

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -1,14 +1,10 @@
-/* global it, describe, before, after, beforeEach, afterEach */
+const { describe, it, before, after, beforeEach, afterEach, mock } = require('node:test')
+const assert = require('node:assert/strict')
 const fs = require('fs')
 const { PDFDocument, PDFName, PDFDict } = require('pdf-lib')
-const chai = require('chai')
-const sinon = require('sinon')
 const rimraf = require('rimraf')
 const ospath = require('path')
-const expect = chai.expect
-const dirtyChai = require('dirty-chai')
-chai.use(dirtyChai)
-require('./helper.js')(chai)
+const helper = require('./helper.js')
 
 const asciidoctor = require('@asciidoctor/core')()
 const converter = require('../lib/converter.js')
@@ -19,20 +15,21 @@ const fixturesPath = (...paths) => ospath.join(__dirname, 'fixtures', ...paths)
 const outputPath = (...paths) => ospath.join(__dirname, 'output', ...paths)
 const cssPath = (...paths) => ospath.join(__dirname, '..', 'css', ...paths)
 
-describe('PDF converter', function () {
-  // launching an headless browser (especially on Travis) can take several tens of seconds
-  this.timeout(30000)
+function assertVisuallyIdentical (outputFile, reference) {
+  const pixelDiff = helper.toVisuallyMatch(reference, outputFile)
+  const relPath = ospath.relative(__dirname, outputFile)
+  assert.strictEqual(pixelDiff, 0, `expected ${relPath} to be visually identical to reference/${reference} but has ${pixelDiff} pixels difference`)
+}
 
+describe('PDF converter', () => {
   before(() => {
     const outputDir = ospath.join(__dirname, 'output')
     rimraf.sync(outputDir)
     fs.mkdirSync(outputDir)
   })
 
-  after(function () {
-    // clean the output directory if there's no failed tests (and if the DEBUG environment variable is absent).
-    const failedTests = this.test.parent.tests.filter(t => t.state === 'failed')
-    if (failedTests.length === 0 && typeof process.env.DEBUG === 'undefined') {
+  after(() => {
+    if (typeof process.env.DEBUG === 'undefined') {
       const outputDir = ospath.join(__dirname, 'output')
       rimraf.sync(outputDir)
       fs.mkdirSync(outputDir)
@@ -80,19 +77,19 @@ describe('PDF converter', function () {
     opts.attributes.reproducible = ''
     opts.to_file = outputFile
     await converter.convert(asciidoctor, { path: fixturesPath(`${inputBaseFileName}.adoc`) }, opts, false)
-    expect(outputFile).to.be.visuallyIdentical(`${outputBaseFileName}.pdf`)
+    assertVisuallyIdentical(outputFile, `${outputBaseFileName}.pdf`)
   }
 
   it('should not encode HTML entity in the PDF outline', async () => {
     const options = { attributes: { toc: 'macro' } }
     const pdfDoc = await convert(fixturesPath('sections.adoc'), outputPath('sections-toc-absent.pdf'), options)
     const refs = getOutlineRefs(pdfDoc)
-    expect(refs.length).to.equal(9)
-    expect(refs[2].get(PDFName.of('Dest')).encodedName).to.equal('/_section_2_black_white')
-    expect(decodePDFHexStringValue(refs[2].get(PDFName.of('Title')).value)).to.equal('Section 2: Black & White')
-    expect(refs[5].get(PDFName.of('Dest')).encodedName).to.equal('/_section_3_typographic_quotes')
-    expect(decodePDFHexStringValue(refs[5].get(PDFName.of('Title')).value)).to.equal('Section 3: “Typographic quotes”')
-    expect(decodePDFHexStringValue(refs[7].get(PDFName.of('Title')).value)).to.equal('Section 4: Asterisk hex * and decimal *')
+    assert.strictEqual(refs.length, 9)
+    assert.strictEqual(refs[2].get(PDFName.of('Dest')).encodedName, '/_section_2_black_white')
+    assert.strictEqual(decodePDFHexStringValue(refs[2].get(PDFName.of('Title')).value), 'Section 2: Black & White')
+    assert.strictEqual(refs[5].get(PDFName.of('Dest')).encodedName, '/_section_3_typographic_quotes')
+    assert.strictEqual(decodePDFHexStringValue(refs[5].get(PDFName.of('Title')).value), 'Section 3: “Typographic quotes”')
+    assert.strictEqual(decodePDFHexStringValue(refs[7].get(PDFName.of('Title')).value), 'Section 4: Asterisk hex * and decimal *')
   })
 
   describe('PDF Outline', () => {
@@ -100,31 +97,31 @@ describe('PDF converter', function () {
       const options = { attributes: { toc: 'macro' } }
       const pdfDoc = await convert(fixturesPath('sections.adoc'), outputPath('sections-toc-absent.pdf'), options)
       const refs = getOutlineRefs(pdfDoc)
-      expect(refs.length).to.equal(9)
-      expect(refs[0].get(PDFName.of('Dest')).encodedName).to.equal('/_section_1')
+      assert.strictEqual(refs.length, 9)
+      assert.strictEqual(refs[0].get(PDFName.of('Dest')).encodedName, '/_section_1')
     })
 
     it('should generate a PDF outline even if the TOC is not enabled', async () => {
       const pdfDoc = await convert(fixturesPath('sections.adoc'), outputPath('sections-toc-disabled.pdf'))
       const refs = getOutlineRefs(pdfDoc)
-      expect(refs.length).to.equal(9)
-      expect(refs[0].get(PDFName.of('Dest')).encodedName).to.equal('/_section_1')
+      assert.strictEqual(refs.length, 9)
+      assert.strictEqual(refs[0].get(PDFName.of('Dest')).encodedName, '/_section_1')
     })
 
     it('should honor toclevels 1 when generating a PDF outline', async () => {
       const options = { attributes: { toclevels: 1 } }
       const pdfDoc = await convert(fixturesPath('sections.adoc'), outputPath('sections-toclevels-1.pdf'), options)
       const refs = getOutlineRefs(pdfDoc)
-      expect(refs.length).to.equal(4)
-      expect(refs[0].get(PDFName.of('Dest')).encodedName).to.equal('/_section_1')
+      assert.strictEqual(refs.length, 4)
+      assert.strictEqual(refs[0].get(PDFName.of('Dest')).encodedName, '/_section_1')
     })
 
     it('should honor toclevels 3 when generating a PDF outline', async () => {
       const options = { attributes: { toclevels: 3 } }
       const pdfDoc = await convert(fixturesPath('sections.adoc'), outputPath('sections-toclevels-1.pdf'), options)
       const refs = getOutlineRefs(pdfDoc)
-      expect(refs.length).to.equal(11)
-      expect(refs[0].get(PDFName.of('Dest')).encodedName).to.equal('/_section_1')
+      assert.strictEqual(refs.length, 11)
+      assert.strictEqual(refs[0].get(PDFName.of('Dest')).encodedName, '/_section_1')
     })
   })
 
@@ -324,8 +321,8 @@ describe('PDF converter', function () {
         const inputFile = fixturesPath(inputFileName)
 
         const pdfDoc = await convert(inputFile, outputFile, options)
-        expect(pdfDoc.getPages().length).to.equal(scenario['expected-page-number'])
-        expect(outputFile).to.be.visuallyIdentical(outputFileName)
+        assert.strictEqual(pdfDoc.getPages().length, scenario['expected-page-number'])
+        assertVisuallyIdentical(outputFile, outputFileName)
       })
     }
   })
@@ -367,12 +364,14 @@ describe('PDF converter', function () {
   })
 
   describe('Timeout', () => {
-    beforeEach(function () {
-      sinon.spy(console, 'error')
+    let errorMock
+
+    beforeEach(() => {
+      errorMock = mock.method(console, 'error')
     })
 
-    afterEach(function () {
-      console.error.restore()
+    afterEach(() => {
+      errorMock.mock.restore()
     })
 
     it('should timeout while navigating', async () => {
@@ -381,9 +380,8 @@ describe('PDF converter', function () {
         delete require.cache[require.resolve('../lib/converter.js')]
         const converter = require('../lib/converter.js')
         await converter.convert(asciidoctor, { path: fixturesPath('title-page.adoc') }, {}, false)
-        const call = console.error.getCall(0)
-        expect(call).to.have.property('firstArg')
-        expect(call.firstArg).to.equal('Unable to generate the PDF - Error: TimeoutError: Navigation timeout of 1 ms exceeded')
+        assert.ok(errorMock.mock.calls.length > 0)
+        assert.strictEqual(errorMock.mock.calls[0].arguments[0], 'Unable to generate the PDF - Error: TimeoutError: Navigation timeout of 1 ms exceeded')
       } finally {
         delete process.env.PUPPETEER_NAVIGATION_TIMEOUT
       }

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -1,10 +1,7 @@
-/* global it, describe */
+const { describe, it } = require('node:test')
+const assert = require('node:assert/strict')
 const ospath = require('path')
 const cheerio = require('cheerio')
-const chai = require('chai')
-const expect = chai.expect
-const dirtyChai = require('dirty-chai')
-chai.use(dirtyChai)
 
 const asciidoctor = require('@asciidoctor/core')()
 const converter = require('../lib/converter.js')
@@ -20,7 +17,7 @@ describe('Default converter', () => {
 
 == Section`)
       const $ = cheerio.load(templates.document(doc))
-      expect($('html').attr('lang')).to.equal('en')
+      assert.strictEqual($('html').attr('lang'), 'en')
     })
 
     it('respect the document lang attribute', () => {
@@ -29,7 +26,7 @@ describe('Default converter', () => {
 
 == Section`)
       const $ = cheerio.load(templates.document(doc))
-      expect($('html').attr('lang')).to.equal('de')
+      assert.strictEqual($('html').attr('lang'), 'de')
     })
 
     it('respect the document nolang attribute', () => {
@@ -38,7 +35,7 @@ describe('Default converter', () => {
 
 == Section`)
       const $ = cheerio.load(templates.document(doc))
-      expect($('html').attr('lang')).to.be.undefined()
+      assert.strictEqual($('html').attr('lang'), undefined)
     })
   })
 
@@ -50,7 +47,7 @@ Guillaume Grossetie
 
 == Section`)
       const $ = cheerio.load(doc.convert({ header_footer: true }))
-      expect($('.title-page > h1').text()).to.equal('Title')
+      assert.strictEqual($('.title-page > h1').text(), 'Title')
     })
 
     it('should include a title page if doctype is book', () => {
@@ -59,7 +56,7 @@ Guillaume Grossetie
 
 == Section`, { doctype: 'book' })
       const $ = cheerio.load(doc.convert({ header_footer: true }))
-      expect($('.title-page > h1').text()).to.equal('Title')
+      assert.strictEqual($('.title-page > h1').text(), 'Title')
     })
 
     it('should not include a title page', () => {
@@ -68,43 +65,43 @@ Guillaume Grossetie
 
 == Section`)
       const $ = cheerio.load(doc.convert({ header_footer: true }))
-      expect($('.title-page > h1').length).to.equal(0)
+      assert.strictEqual($('.title-page > h1').length, 0)
     })
 
     it('should not include a title page if the document title is empty', () => {
       const doc = asciidoctor.load('Hello world!', { attributes: { 'title-page': '' } })
       const $ = cheerio.load(doc.convert({ header_footer: true }))
-      expect($('.title-page > h1').length).to.equal(0)
+      assert.strictEqual($('.title-page > h1').length, 0)
     })
 
     it('should not include a document title if the document title is empty', () => {
       const doc = asciidoctor.load('Hello world!')
       const $ = cheerio.load(doc.convert({ header_footer: true }))
-      expect($('.title-document > h1').length).to.equal(0)
+      assert.strictEqual($('.title-document > h1').length, 0)
     })
   })
 
   it('should replace the default stylesheet with a custom stylesheet', () => {
     const doc = asciidoctor.load('[.greetings]#Hello world#', { attributes: { stylesheet: fixturesPath('custom.css') } })
     const $ = cheerio.load(doc.convert({ header_footer: true }))
-    expect($('head').html()).to.not.have.string('Asciidoctor default stylesheet')
-    expect($(`head > link[href="${fixturesPath('custom.css')}"]`).length).to.equal(1)
+    assert.ok(!$('head').html().includes('Asciidoctor default stylesheet'))
+    assert.strictEqual($(`head > link[href="${fixturesPath('custom.css')}"]`).length, 1)
   })
 
   it('should load multiple stylesheets', () => {
     const doc = asciidoctor.load('Hello world', { attributes: { stylesheet: `${fixturesPath('variable.css')}, ,${fixturesPath('theme.css')},` } })
     const $ = cheerio.load(doc.convert({ header_footer: true }))
-    expect($('head').html()).to.not.have.string('Asciidoctor default stylesheet')
-    expect($(`head > link[href="${fixturesPath('variable.css')}"]`).length).to.equal(1)
-    expect($(`head > link[href="${fixturesPath('theme.css')}"]`).length).to.equal(1)
+    assert.ok(!$('head').html().includes('Asciidoctor default stylesheet'))
+    assert.strictEqual($(`head > link[href="${fixturesPath('variable.css')}"]`).length, 1)
+    assert.strictEqual($(`head > link[href="${fixturesPath('theme.css')}"]`).length, 1)
   })
 
   it('should resolve the stylesheet when using a relative path', () => {
     const doc = asciidoctor.load('[.greetings]#Hello world#', { attributes: { stylesheet: ospath.join('@asciidoctor', 'core', 'dist', 'css', 'asciidoctor.css') } })
     const $ = cheerio.load(doc.convert({ header_footer: true }))
-    expect($('head').html()).to.not.have.string('Asciidoctor default stylesheet')
+    assert.ok(!$('head').html().includes('Asciidoctor default stylesheet'))
     const href = ospath.resolve(ospath.join(__dirname, '..', 'node_modules', '@asciidoctor', 'core', 'dist', 'css', 'asciidoctor.css'))
-    expect($(`head > link[href="${href}"]`).length).to.equal(1)
+    assert.strictEqual($(`head > link[href="${href}"]`).length, 1)
   })
 
   describe('Stem', () => {
@@ -117,9 +114,9 @@ Guillaume Grossetie
 
 == Section`)
       const $ = cheerio.load(templates.document(doc))
-      expect($(`script[src="${mathjaxFileUrl}"]`).length).to.equal(1)
+      assert.strictEqual($(`script[src="${mathjaxFileUrl}"]`).length, 1)
       // by default equation numbering is not enabled
-      expect($('script[data-type="mathjax-config"]').html()).to.have.string('tags: "none"')
+      assert.ok($('script[data-type="mathjax-config"]').html().includes('tags: "none"'))
     })
 
     it('should not include MathML when stem is not set', () => {
@@ -128,7 +125,7 @@ Guillaume Grossetie
 
 == Section`)
       const $ = cheerio.load(templates.document(doc))
-      expect($(`script[src="${mathjaxFileUrl}"]`).length).to.equal(0)
+      assert.strictEqual($(`script[src="${mathjaxFileUrl}"]`).length, 0)
     })
 
     it('should not include MathML when stem is not present', () => {
@@ -136,7 +133,7 @@ Guillaume Grossetie
 
 == Section`)
       const $ = cheerio.load(templates.document(doc))
-      expect($(`script[src="${mathjaxFileUrl}"]`).length).to.equal(0)
+      assert.strictEqual($(`script[src="${mathjaxFileUrl}"]`).length, 0)
     })
 
     it('should add equation numbers when eqnums equals AMS', () => {
@@ -146,8 +143,8 @@ Guillaume Grossetie
 
 == Section`)
       const $ = cheerio.load(templates.document(doc))
-      expect($(`script[src="${mathjaxFileUrl}"]`).length).to.equal(1)
-      expect($('script[data-type="mathjax-config"]').html()).to.have.string('tags: "ams"')
+      assert.strictEqual($(`script[src="${mathjaxFileUrl}"]`).length, 1)
+      assert.ok($('script[data-type="mathjax-config"]').html().includes('tags: "ams"'))
     })
 
     it('should add equation numbers when eqnums is present', () => {
@@ -157,9 +154,9 @@ Guillaume Grossetie
 
 == Section`)
       const $ = cheerio.load(templates.document(doc))
-      expect($(`script[src="${mathjaxFileUrl}"]`).length).to.equal(1)
+      assert.strictEqual($(`script[src="${mathjaxFileUrl}"]`).length, 1)
       // If eqnums is empty, the value will be "ams"
-      expect($('script[data-type="mathjax-config"]').html()).to.have.string('tags: "ams"')
+      assert.ok($('script[data-type="mathjax-config"]').html().includes('tags: "ams"'))
     })
 
     it('should add equation numbers when eqnums equals all', () => {
@@ -169,8 +166,8 @@ Guillaume Grossetie
 
 == Section`)
       const $ = cheerio.load(templates.document(doc))
-      expect($(`script[src="${mathjaxFileUrl}"]`).length).to.equal(1)
-      expect($('script[data-type="mathjax-config"]').html()).to.have.string('tags: "all"')
+      assert.strictEqual($(`script[src="${mathjaxFileUrl}"]`).length, 1)
+      assert.ok($('script[data-type="mathjax-config"]').html().includes('tags: "all"'))
     })
   })
 
@@ -182,7 +179,7 @@ Guillaume Grossetie
 [TIP]
 It's possible to use emojis as admonition.`)
       const $ = cheerio.load(doc.convert())
-      expect($('td.icon > .title').html()).to.equal(':bulb:')
+      assert.strictEqual($('td.icon > .title').html(), ':bulb:')
     })
   })
 
@@ -194,28 +191,28 @@ It's possible to use emojis as admonition.`)
 
 icon:address-book[]`, { safe: 'safe' })
         const $ = cheerio.load(doc.convert())
-        expect($('svg[data-prefix="fas"][data-icon="address-book"]').html()).to.equal('<path fill="currentColor" d="M96 0C60.7 0 32 28.7 32 64V448c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V64c0-35.3-28.7-64-64-64H96zM208 288h64c44.2 0 80 35.8 80 80c0 8.8-7.2 16-16 16H144c-8.8 0-16-7.2-16-16c0-44.2 35.8-80 80-80zm96-96c0 35.3-28.7 64-64 64s-64-28.7-64-64s28.7-64 64-64s64 28.7 64 64zM512 80c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V80zM496 192c-8.8 0-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm16 144c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V336z"></path>')
+        assert.strictEqual($('svg[data-prefix="fas"][data-icon="address-book"]').html(), '<path fill="currentColor" d="M96 0C60.7 0 32 28.7 32 64V448c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V64c0-35.3-28.7-64-64-64H96zM208 288h64c44.2 0 80 35.8 80 80c0 8.8-7.2 16-16 16H144c-8.8 0-16-7.2-16-16c0-44.2 35.8-80 80-80zm96-96c0 35.3-28.7 64-64 64s-64-28.7-64-64s28.7-64 64-64s64 28.7 64 64zM512 80c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V80zM496 192c-8.8 0-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm16 144c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V336z"></path>')
       })
       it('should render a solid FontAwesome SVG icon (default)', () => {
         const doc = asciidoctor.load(`:icontype: svg
 
 icon:address-book[]`)
         const $ = cheerio.load(doc.convert())
-        expect($('svg[data-prefix="fas"][data-icon="address-book"]').html()).to.equal('<path fill="currentColor" d="M96 0C60.7 0 32 28.7 32 64V448c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V64c0-35.3-28.7-64-64-64H96zM208 288h64c44.2 0 80 35.8 80 80c0 8.8-7.2 16-16 16H144c-8.8 0-16-7.2-16-16c0-44.2 35.8-80 80-80zm96-96c0 35.3-28.7 64-64 64s-64-28.7-64-64s28.7-64 64-64s64 28.7 64 64zM512 80c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V80zM496 192c-8.8 0-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm16 144c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V336z"></path>')
+        assert.strictEqual($('svg[data-prefix="fas"][data-icon="address-book"]').html(), '<path fill="currentColor" d="M96 0C60.7 0 32 28.7 32 64V448c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V64c0-35.3-28.7-64-64-64H96zM208 288h64c44.2 0 80 35.8 80 80c0 8.8-7.2 16-16 16H144c-8.8 0-16-7.2-16-16c0-44.2 35.8-80 80-80zm96-96c0 35.3-28.7 64-64 64s-64-28.7-64-64s28.7-64 64-64s64 28.7 64 64zM512 80c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V80zM496 192c-8.8 0-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm16 144c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V336z"></path>')
       })
       it('should render a regular FontAwesome SVG icon (default)', () => {
         const doc = asciidoctor.load(`:icontype: svg
 
 icon:address-book[set=far]`)
         const $ = cheerio.load(doc.convert())
-        expect($('svg[data-prefix="far"][data-icon="address-book"]').html()).to.equal('<path fill="currentColor" d="M272 288h-64C163.8 288 128 323.8 128 368C128 376.8 135.2 384 144 384h192c8.836 0 16-7.164 16-16C352 323.8 316.2 288 272 288zM240 256c35.35 0 64-28.65 64-64s-28.65-64-64-64c-35.34 0-64 28.65-64 64S204.7 256 240 256zM496 320H480v96h16c8.836 0 16-7.164 16-16v-64C512 327.2 504.8 320 496 320zM496 64H480v96h16C504.8 160 512 152.8 512 144v-64C512 71.16 504.8 64 496 64zM496 192H480v96h16C504.8 288 512 280.8 512 272v-64C512 199.2 504.8 192 496 192zM384 0H96C60.65 0 32 28.65 32 64v384c0 35.35 28.65 64 64 64h288c35.35 0 64-28.65 64-64V64C448 28.65 419.3 0 384 0zM400 448c0 8.836-7.164 16-16 16H96c-8.836 0-16-7.164-16-16V64c0-8.838 7.164-16 16-16h288c8.836 0 16 7.162 16 16V448z"></path>')
+        assert.strictEqual($('svg[data-prefix="far"][data-icon="address-book"]').html(), '<path fill="currentColor" d="M272 288h-64C163.8 288 128 323.8 128 368C128 376.8 135.2 384 144 384h192c8.836 0 16-7.164 16-16C352 323.8 316.2 288 272 288zM240 256c35.35 0 64-28.65 64-64s-28.65-64-64-64c-35.34 0-64 28.65-64 64S204.7 256 240 256zM496 320H480v96h16c8.836 0 16-7.164 16-16v-64C512 327.2 504.8 320 496 320zM496 64H480v96h16C504.8 160 512 152.8 512 144v-64C512 71.16 504.8 64 496 64zM496 192H480v96h16C504.8 288 512 280.8 512 272v-64C512 199.2 504.8 192 496 192zM384 0H96C60.65 0 32 28.65 32 64v384c0 35.35 28.65 64 64 64h288c35.35 0 64-28.65 64-64V64C448 28.65 419.3 0 384 0zM400 448c0 8.836-7.164 16-16 16H96c-8.836 0-16-7.164-16-16V64c0-8.838 7.164-16 16-16h288c8.836 0 16 7.162 16 16V448z"></path>')
       })
       it('should render a brand FontAwesome SVG icon (default)', () => {
         const doc = asciidoctor.load(`:icontype: svg
 
 icon:chrome@fab[]`)
         const $ = cheerio.load(doc.convert())
-        expect($('svg[data-prefix="fab"][data-icon="chrome"]').html()).to.equal('<path fill="currentColor" d="M0 256C0 209.4 12.47 165.6 34.27 127.1L144.1 318.3C166 357.5 207.9 384 256 384C270.3 384 283.1 381.7 296.8 377.4L220.5 509.6C95.9 492.3 0 385.3 0 256zM365.1 321.6C377.4 302.4 384 279.1 384 256C384 217.8 367.2 183.5 340.7 160H493.4C505.4 189.6 512 222.1 512 256C512 397.4 397.4 511.1 256 512L365.1 321.6zM477.8 128H256C193.1 128 142.3 172.1 130.5 230.7L54.19 98.47C101 38.53 174 0 256 0C350.8 0 433.5 51.48 477.8 128V128zM168 256C168 207.4 207.4 168 256 168C304.6 168 344 207.4 344 256C344 304.6 304.6 344 256 344C207.4 344 168 304.6 168 256z"></path>')
+        assert.strictEqual($('svg[data-prefix="fab"][data-icon="chrome"]').html(), '<path fill="currentColor" d="M0 256C0 209.4 12.47 165.6 34.27 127.1L144.1 318.3C166 357.5 207.9 384 256 384C270.3 384 283.1 381.7 296.8 377.4L220.5 509.6C95.9 492.3 0 385.3 0 256zM365.1 321.6C377.4 302.4 384 279.1 384 256C384 217.8 367.2 183.5 340.7 160H493.4C505.4 189.6 512 222.1 512 256C512 397.4 397.4 511.1 256 512L365.1 321.6zM477.8 128H256C193.1 128 142.3 172.1 130.5 230.7L54.19 98.47C101 38.53 174 0 256 0C350.8 0 433.5 51.48 477.8 128V128zM168 256C168 207.4 207.4 168 256 168C304.6 168 344 207.4 344 256C344 304.6 304.6 344 256 344C207.4 344 168 304.6 168 256z"></path>')
       })
     })
   })
@@ -231,7 +228,7 @@ icon:chrome@fab[]`)
 
 == Section 3`, { safe: 'safe' })
       const $ = cheerio.load(doc.convert())
-      expect($('#toc > ul.sectlevel1 > li')).to.have.length(3)
+      assert.strictEqual($('#toc > ul.sectlevel1 > li').length, 3)
     })
 
     it('should not add a toc when there\'s no section', () => {
@@ -240,7 +237,7 @@ icon:chrome@fab[]`)
 
 Just a preamble.`, { safe: 'safe' })
       const $ = cheerio.load(doc.convert())
-      expect($('#toc > ul.sectlevel1 > li')).to.have.length(0)
+      assert.strictEqual($('#toc > ul.sectlevel1 > li').length, 0)
     })
 
     it('should not add a toc in the header when toc placement is macro', () => {
@@ -253,12 +250,12 @@ Just a preamble.`, { safe: 'safe' })
 
 == Section 3`, { safe: 'safe' })
       const $ = cheerio.load(doc.convert())
-      expect($('#toc > ul.sectlevel1 > li')).to.have.length(0)
+      assert.strictEqual($('#toc > ul.sectlevel1 > li').length, 0)
     })
 
     it('should use a template directory (Nunjucks)', () => {
       const html = asciidoctor.convert('Hello *world*', { template_dirs: [fixturesPath('templates', 'nunjucks')] })
-      expect(html).to.equal('<p class="nunjucks">Hello <strong>world</strong></p>')
+      assert.strictEqual(html, '<p class="nunjucks">Hello <strong>world</strong></p>')
     })
   })
 })


### PR DESCRIPTION
- Migrate all test files to node:test (describe/it/before/after/mock)
- Replace chai assertions with node:assert/strict
- Replace sinon spy with mock.method from node:test
- Simplify helper.js to export toVisuallyMatch directly
- Update engines to >=18 (required for node:test features)
- Update CI workflows to Node 24