### PR TITLE
Upgrade @asciidoctor/core to v4

### DIFF
--- a/bin/asciidoctor-pdf
+++ b/bin/asciidoctor-pdf
@@ -1,21 +1,10 @@
 #!/usr/bin/env node
 
-'use strict'
+import { PdfOptions, PdfInvoker } from '../lib/cli.js'
 
 process.title = 'asciidoctor-pdf'
-const { PdfOptions, PdfInvoker } = require('../lib/cli.js')
-
-;(async () => {
-  console.warn('WARN: `asciidoctor-pdf` is deprecated and will be removed in a future version, please use `asciidoctor-web-pdf` instead')
-  const options = new PdfOptions().parse(process.argv)
-  return new PdfInvoker(options).invoke()
-})()
-.then((result) => {
-  if (result.exit) {
-    process.exit(0)
-  }
-})
-.catch((error) => {
+console.warn('WARN: `asciidoctor-pdf` is deprecated and will be removed in a future version, please use `asciidoctor-web-pdf` instead')
+new PdfInvoker(new PdfOptions().parse(process.argv)).invoke().catch((error) => {
   console.error('ERROR: ', error)
   process.exit(1)
 })

--- a/bin/asciidoctor-web-pdf
+++ b/bin/asciidoctor-web-pdf
@@ -1,20 +1,9 @@
 #!/usr/bin/env node
 
-'use strict'
+import { PdfOptions, PdfInvoker } from '../lib/cli.js'
 
 process.title = 'asciidoctor-web-pdf'
-const { PdfOptions, PdfInvoker } = require('../lib/cli.js')
-
-;(async () => {
-  const options = new PdfOptions().parse(process.argv)
-  return new PdfInvoker(options).invoke()
-})()
-.then((result) => {
-  if (result.exit) {
-    process.exit(0)
-  }
-})
-.catch((error) => {
+new PdfInvoker(new PdfOptions().parse(process.argv)).invoke().catch((error) => {
   console.error('ERROR: ', error)
   process.exit(1)
 })

--- a/lib/browser.js
+++ b/lib/browser.js
@@ -1,5 +1,8 @@
-const ospath = require('node:path')
-const puppeteer = require('puppeteer')
+import { createRequire } from 'node:module'
+import ospath from 'node:path'
+import puppeteer from 'puppeteer'
+
+const require = createRequire(import.meta.url)
 
 const BLANK_PAGE_URL = 'about:blank'
 const isSea = (() => {
@@ -52,7 +55,7 @@ const getPuppeteerExecutablePath = () => {
 }
 const chromiumExecutablePath = getPuppeteerExecutablePath()
 
-class Browser {
+export default class Browser {
   constructor() {
     const puppeteerDefaultTimeout = process.env.PUPPETEER_DEFAULT_TIMEOUT
     this.navigationTimeout =
@@ -176,10 +179,6 @@ class Browser {
     const puppeteerConfig = {
       executablePath: await Promise.resolve(chromiumExecutablePath),
       headless: !preview,
-      // --no-sandbox:: Disables the sandbox for all process types that are normally sandboxed.
-      // --allow-file-access-from-files:: Allows file:// URIs to read other file:// URIs.
-      // --export-tagged-pdf:: Generates a tagged (accessible) file when printing to PDF. The plan is for this to go away once tagged PDFs become the default. See https://crbug.com/607777.
-      // Reference: https://peter.sh/experiments/chromium-command-line-switches/
       args: [
         '--no-sandbox',
         '--allow-file-access-from-files',
@@ -192,5 +191,3 @@ class Browser {
     this.underlyingBrowser = await puppeteer.launch(puppeteerConfig)
   }
 }
-
-module.exports = Browser

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,12 +2,12 @@ import { createRequire } from 'node:module'
 import { dirname, isAbsolute, join, resolve, sep } from 'node:path'
 import { Invoker, Options } from 'asciidoctor/cli'
 import chokidar from 'chokidar'
+import pkg from '../package.json' with { type: 'json' }
 import {
   convert as convertPdf,
   registerTemplateConverter,
 } from './converter.js'
 import Lock from './lock.js'
-import pkg from '../package.json' with { type: 'json' }
 
 const require = createRequire(import.meta.url)
 const processorLock = new Lock()

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,298 +1,161 @@
-const Lock = require('./lock.js')
+import { createRequire } from 'node:module'
+import { dirname, isAbsolute, join, resolve, sep } from 'node:path'
+import { Invoker, Options } from 'asciidoctor/cli'
+import chokidar from 'chokidar'
+import {
+  convert as convertPdf,
+  registerTemplateConverter,
+} from './converter.js'
+import Lock from './lock.js'
+
+const require = createRequire(import.meta.url)
 const pkg = require('../package.json')
-const { parseArgs } = require('node:util')
-const { getVersion, getCoreVersion, Extensions } = require('@asciidoctor/core')
-const chokidar = require('chokidar')
-const ospath = require('node:path')
 const processorLock = new Lock()
 
-const converter = require('./converter.js')
-
 const DOT_RELATIVE_RX = new RegExp(
-  `^\\.{1,2}[/${ospath.sep.replace('/', '').replace('\\', '\\\\')}]`,
+  `^\\.{1,2}[/${sep.replace('/', '').replace('\\', '\\\\')}]`,
 )
 
 function requireLibrary(requirePath, cwd = process.cwd()) {
   if (requirePath.charAt(0) === '.' && DOT_RELATIVE_RX.test(requirePath)) {
-    requirePath = ospath.resolve(requirePath)
-  } else if (!ospath.isAbsolute(requirePath)) {
-    const paths = [cwd, ospath.dirname(__dirname)].map((start) =>
-      ospath.join(start, 'node_modules'),
+    requirePath = resolve(requirePath)
+  } else if (!isAbsolute(requirePath)) {
+    const paths = [cwd, dirname(import.meta.dirname)].map((start) =>
+      join(start, 'node_modules'),
     )
     requirePath = require.resolve(requirePath, { paths })
   }
   return require(requirePath)
 }
 
-function prepareProcessor(args) {
-  const requirePaths = args.require
-  if (requirePaths) {
-    requirePaths.forEach((requirePath) => {
-      const lib = requireLibrary(requirePath)
-      if (lib && typeof lib.register === 'function') {
-        lib.register(Extensions)
-      }
+export class PdfOptions extends Options {
+  constructor() {
+    super()
+    this.addOption('template-require', {
+      type: 'string',
+      describe: 'require the specified template script',
+      metavar: '<script>',
+    })
+    this.addOption('watch', {
+      type: 'boolean',
+      short: 'w',
+      describe: 'enable watch mode',
+    })
+    this.addOption('preview', {
+      type: 'boolean',
+      describe: 'open browser for inspecting HTML before PDF conversion',
     })
   }
-}
 
-async function readFromStdin() {
-  return new Promise((resolve, reject) => {
-    const chunks = []
-    process.stdin.on('data', (chunk) => chunks.push(chunk))
-    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString()))
-    process.stdin.on('error', reject)
-  })
-}
-
-function versionString() {
-  const releaseName = process.release ? process.release.name : 'node'
-  return `Asciidoctor Web PDF ${pkg.version}
-Asciidoctor.js ${getVersion()} (Asciidoctor core ${getCoreVersion()}) [https://asciidoctor.org]
-Runtime Environment (${releaseName} ${process.version} on ${process.platform})`
-}
-
-function helpString() {
-  return `Usage: asciidoctor-web-pdf [options...] files...
-Translate the AsciiDoc source file or file(s) into PDF format.
-
-Options:
-  -b, --backend <backend>          set output format backend
-  -d, --doctype <doctype>          document type [article, book, manpage, inline]
-  -o, --out-file <file>            output file (default: based on input); use '' to output to STDOUT
-  -S, --safe-mode <mode>           safe mode level [unsafe, safe, server, secure]
-  -e, --embedded                   suppress enclosing document structure
-  -s, --no-header-footer           suppress enclosing document structure
-  -n, --section-numbers            auto-number section titles
-  -B, --base-dir <dir>             base directory containing the document and resources
-  -D, --destination-dir <dir>      destination output directory
-      --failure-level <level>      minimum logging level for non-zero exit [INFO, WARN, ERROR, FATAL]
-  -q, --quiet                      suppress warnings
-      --trace                      include backtrace information on errors
-  -v, --verbose                    enable verbose mode
-  -t, --timings                    enable timings mode
-  -a, --attribute <key=value>      document attribute (may be specified multiple times)
-  -r, --require <library>          require library before executing processor (may be specified multiple times)
-  -V, --version                    display version info
-  -h, --help                       show this help
-      --template-require <script>  require the specified template script
-  -w, --watch                      enable watch mode
-      --preview                    open browser for inspecting HTML before PDF conversion`
-}
-
-const CLI_OPTIONS = {
-  backend: { type: 'string', short: 'b' },
-  doctype: { type: 'string', short: 'd' },
-  'out-file': { type: 'string', short: 'o' },
-  'safe-mode': { type: 'string', short: 'S' },
-  embedded: { type: 'boolean', short: 'e' },
-  'no-header-footer': { type: 'boolean', short: 's' },
-  'section-numbers': { type: 'boolean', short: 'n' },
-  'base-dir': { type: 'string', short: 'B' },
-  'destination-dir': { type: 'string', short: 'D' },
-  'failure-level': { type: 'string' },
-  quiet: { type: 'boolean', short: 'q' },
-  trace: { type: 'boolean' },
-  verbose: { type: 'boolean', short: 'v' },
-  timings: { type: 'boolean', short: 't' },
-  attribute: { type: 'string', short: 'a', multiple: true },
-  require: { type: 'string', short: 'r', multiple: true },
-  version: { type: 'boolean', short: 'V' },
-  help: { type: 'boolean', short: 'h' },
-  'template-require': { type: 'string' },
-  watch: { type: 'boolean', short: 'w' },
-  preview: { type: 'boolean' },
-}
-
-function buildAsciidoctorOptions(args, extraAttributes = []) {
-  const attributes = [...extraAttributes]
-  if (args['section-numbers']) {
-    attributes.push('sectnums')
-  }
-  if (args.attribute) {
-    attributes.push(...args.attribute)
-  }
-  const quiet = args.quiet || false
-  const verbose = args.verbose || false
-  const verboseMode = quiet ? 0 : verbose ? 2 : 1
-  const embedded =
-    args.embedded === true || args['no-header-footer'] === true || false
-
-  const options = {
-    safe: args['safe-mode'] || 'unsafe',
-    standalone: !embedded,
-    verbose: verboseMode,
-    timings: args.timings || false,
-    trace: args.trace || false,
-    attributes,
-    mkdirs: true,
-  }
-  if (args.doctype) options.doctype = args.doctype
-  if (args.backend) options.backend = args.backend
-  if (args['base-dir'] != null) options.base_dir = args['base-dir']
-  if (args['destination-dir'] != null) options.to_dir = args['destination-dir']
-
-  const outFile = args['out-file']
-  if (outFile === '') {
-    options.to_file = process.stdout
-  } else if (outFile != null) {
-    options.to_file = outFile
-  }
-  return options
-}
-
-async function convertFiles(files, args, asciidoctorOptions, verbose, preview) {
-  for (const file of files) {
-    if (verbose) {
-      console.log(`converting file ${file.contents ? '-' : file.path}`)
-    }
-    await converter.convert(
-      file,
-      asciidoctorOptions,
-      args.timings,
-      args.watch,
-      preview,
-    )
+  _buildConvertOptions(extraAttrs = []) {
+    return super._buildConvertOptions([
+      'env-web-pdf',
+      'env=web-pdf',
+      ...extraAttrs,
+    ])
   }
 }
 
-class PdfOptions {
-  constructor() {
-    this._defaultAttributes = ['env-web-pdf', 'env=web-pdf']
-  }
-
-  parse(argv) {
-    const processArgs = argv.slice(2)
-    let parsed
-    try {
-      parsed = parseArgs({
-        args: processArgs,
-        options: CLI_OPTIONS,
-        allowPositionals: true,
-      })
-    } catch (err) {
-      console.error(`Error: ${err.message}`)
-      process.exit(1)
-    }
-    const { values, positionals } = parsed
-    const stdin =
-      positionals.length === 0 && processArgs[processArgs.length - 1] === '-'
-    if (stdin && values['out-file'] == null) {
-      values['out-file'] = ''
-    }
-    const asciidoctorOptions = buildAsciidoctorOptions(
-      values,
-      this._defaultAttributes,
-    )
-    return {
-      argv,
-      args: { ...values, files: positionals },
-      options: asciidoctorOptions,
-      stdin,
-    }
-  }
-}
-
-class PdfInvoker {
-  constructor(options) {
-    this.options = options
+export class PdfInvoker extends Invoker {
+  version() {
+    return `Asciidoctor Web PDF ${pkg.version} [https://github.com/ggrossetie/asciidoctor-web-pdf]\n${super.version()}`
   }
 
   async invoke() {
-    const cliOptions = this.options
-    const processArgs = cliOptions.argv.slice(2)
-    const { args } = cliOptions
-    const { verbose, version, files, watch, preview } = args
-    const templateRequireLib = args['template-require']
-
-    if (args.help) {
-      console.log(helpString())
-      return { exit: true }
-    }
-    if (version || (verbose && processArgs.length === 1)) {
-      console.log(versionString())
-      return { exit: true }
-    }
-
+    const { values } = this.options
+    const templateRequireLib = values['template-require']
     let templates
     if (templateRequireLib) {
-      templates = requireLibrary(templateRequireLib)
+      const mod = requireLibrary(templateRequireLib)
+      templates = mod.templates || mod
     } else {
-      templates = require('./document/document-converter').templates
+      ;({ templates } = await import('./document/document-converter.js'))
     }
-    converter.registerTemplateConverter(templates)
-    prepareProcessor(args)
+    registerTemplateConverter(templates)
+    return super.invoke()
+  }
 
-    const asciidoctorOptions = cliOptions.options
+  async convertFiles(files, options, values) {
+    const { watch, preview, timings, verbose } = values
+    await this._convertAll(files, options, timings, watch, preview, verbose)
 
-    if (cliOptions.stdin) {
-      const fictiveInputFile = `${asciidoctorOptions.base_dir || process.cwd()}/asciidoctor-pdf-stdin.adoc`
-      const data = await readFromStdin()
-      const fileObjects = [{ path: fictiveInputFile, contents: data }]
-      await convertFiles(
-        fileObjects,
-        args,
-        asciidoctorOptions,
-        verbose,
-        preview,
+    if (watch) {
+      console.log(
+        'Watch mode entered, needs to be manually terminated using Ctrl+C!',
       )
-      return { exit: false }
-    } else if (files && files.length > 0) {
-      const fileObjects = files.map((file) => ({ path: file }))
-      await convertFiles(
-        fileObjects,
-        args,
-        asciidoctorOptions,
-        verbose,
-        preview,
-      )
-      if (watch) {
-        const watchFiles = files.map((file) => {
-          const dirname = ospath.dirname(file)
-          const allSubdirPath = ospath.join(dirname, '**')
-          return [
-            ospath.join(allSubdirPath, '*.css'),
-            ospath.join(allSubdirPath, '*.js'),
-            ospath.join(allSubdirPath, '*.adoc'),
-            file,
-          ]
+      const watchFiles = files.flatMap((file) => {
+        const dir = dirname(file)
+        const allSubdirPath = join(dir, '**')
+        return [
+          join(allSubdirPath, '*.css'),
+          join(allSubdirPath, '*.js'),
+          join(allSubdirPath, '*.adoc'),
+          file,
+        ]
+      })
+      chokidar
+        .watch(watchFiles, { ignored: /(^|[/\\])\../ })
+        .on('change', async (changedPath) => {
+          if (verbose) console.log(`  file changed ${changedPath}`)
+          try {
+            const hasQueuedEvents = await processorLock.acquire()
+            if (!hasQueuedEvents) {
+              await this._convertAll(
+                files,
+                options,
+                timings,
+                watch,
+                preview,
+                verbose,
+              )
+            }
+          } finally {
+            processorLock.release()
+          }
         })
-        console.log(
-          'Watch mode entered, needs to be manually terminated using Ctrl+C!',
-        )
-        chokidar
-          .watch(watchFiles, { ignored: /(^|[/\\])\../ })
-          .on('change', async (changedPath) => {
-            if (verbose) {
-              console.log(`  file changed ${changedPath}`)
-            }
-            try {
-              const hasQueuedEvents = await processorLock.acquire()
-              if (!hasQueuedEvents) {
-                await convertFiles(
-                  fileObjects,
-                  args,
-                  asciidoctorOptions,
-                  verbose,
-                  preview,
-                )
-              }
-            } finally {
-              processorLock.release()
-            }
-          })
-        return { exit: false }
-      } else {
-        return { exit: true }
-      }
-    } else {
-      console.log(helpString())
-      return { exit: true }
+    }
+  }
+
+  async _convertFromStdin(options) {
+    const { values } = this.options
+    const data = await readFromStdin()
+    const fictiveInputFile = join(
+      options.base_dir || process.cwd(),
+      'asciidoctor-pdf-stdin.adoc',
+    )
+    await convertPdf(
+      { path: fictiveInputFile, contents: data },
+      options,
+      values.timings,
+      false,
+      values.preview,
+    )
+  }
+
+  async _exit(failureLevel) {
+    if (this.options.values.watch) {
+      return
+    }
+    return super._exit(failureLevel)
+  }
+
+  async _convertAll(files, options, timings, watch, preview, verbose) {
+    for (const file of files) {
+      if (verbose) console.log(`converting file ${file}`)
+      await convertPdf({ path: file }, options, timings, watch, preview)
     }
   }
 }
 
-module.exports = {
-  PdfOptions,
-  PdfInvoker,
+function readFromStdin() {
+  return new Promise((resolve, reject) => {
+    let data = ''
+    process.stdin.setEncoding('utf8')
+    process.stdin.on('readable', () => {
+      const chunk = process.stdin.read()
+      if (chunk !== null) data += chunk
+    })
+    process.stdin.on('error', reject)
+    process.stdin.on('end', () => resolve(data.replace(/\n$/, '')))
+  })
 }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -7,9 +7,9 @@ import {
   registerTemplateConverter,
 } from './converter.js'
 import Lock from './lock.js'
+import pkg from '../package.json' with { type: 'json' }
 
 const require = createRequire(import.meta.url)
-const pkg = require('../package.json')
 const processorLock = new Lock()
 
 const DOT_RELATIVE_RX = new RegExp(

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -1,23 +1,156 @@
 const Lock = require('./lock.js')
 const pkg = require('../package.json')
-const { Options, Invoker, processor } = require('@asciidoctor/cli')
+const { parseArgs } = require('node:util')
+const { getVersion, getCoreVersion, Extensions } = require('@asciidoctor/core')
 const chokidar = require('chokidar')
-const path = require('node:path')
+const ospath = require('node:path')
 const processorLock = new Lock()
 
 const converter = require('./converter.js')
 
-async function convertFiles(files, argv, options, verbose, preview) {
+const DOT_RELATIVE_RX = new RegExp(
+  `^\\.{1,2}[/${ospath.sep.replace('/', '').replace('\\', '\\\\')}]`,
+)
+
+function requireLibrary(requirePath, cwd = process.cwd()) {
+  if (requirePath.charAt(0) === '.' && DOT_RELATIVE_RX.test(requirePath)) {
+    requirePath = ospath.resolve(requirePath)
+  } else if (!ospath.isAbsolute(requirePath)) {
+    const paths = [cwd, ospath.dirname(__dirname)].map((start) =>
+      ospath.join(start, 'node_modules'),
+    )
+    requirePath = require.resolve(requirePath, { paths })
+  }
+  return require(requirePath)
+}
+
+function prepareProcessor(args) {
+  const requirePaths = args.require
+  if (requirePaths) {
+    requirePaths.forEach((requirePath) => {
+      const lib = requireLibrary(requirePath)
+      if (lib && typeof lib.register === 'function') {
+        lib.register(Extensions)
+      }
+    })
+  }
+}
+
+async function readFromStdin() {
+  return new Promise((resolve, reject) => {
+    const chunks = []
+    process.stdin.on('data', (chunk) => chunks.push(chunk))
+    process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString()))
+    process.stdin.on('error', reject)
+  })
+}
+
+function versionString() {
+  const releaseName = process.release ? process.release.name : 'node'
+  return `Asciidoctor Web PDF ${pkg.version}
+Asciidoctor.js ${getVersion()} (Asciidoctor core ${getCoreVersion()}) [https://asciidoctor.org]
+Runtime Environment (${releaseName} ${process.version} on ${process.platform})`
+}
+
+function helpString() {
+  return `Usage: asciidoctor-web-pdf [options...] files...
+Translate the AsciiDoc source file or file(s) into PDF format.
+
+Options:
+  -b, --backend <backend>          set output format backend
+  -d, --doctype <doctype>          document type [article, book, manpage, inline]
+  -o, --out-file <file>            output file (default: based on input); use '' to output to STDOUT
+  -S, --safe-mode <mode>           safe mode level [unsafe, safe, server, secure]
+  -e, --embedded                   suppress enclosing document structure
+  -s, --no-header-footer           suppress enclosing document structure
+  -n, --section-numbers            auto-number section titles
+  -B, --base-dir <dir>             base directory containing the document and resources
+  -D, --destination-dir <dir>      destination output directory
+      --failure-level <level>      minimum logging level for non-zero exit [INFO, WARN, ERROR, FATAL]
+  -q, --quiet                      suppress warnings
+      --trace                      include backtrace information on errors
+  -v, --verbose                    enable verbose mode
+  -t, --timings                    enable timings mode
+  -a, --attribute <key=value>      document attribute (may be specified multiple times)
+  -r, --require <library>          require library before executing processor (may be specified multiple times)
+  -V, --version                    display version info
+  -h, --help                       show this help
+      --template-require <script>  require the specified template script
+  -w, --watch                      enable watch mode
+      --preview                    open browser for inspecting HTML before PDF conversion`
+}
+
+const CLI_OPTIONS = {
+  backend: { type: 'string', short: 'b' },
+  doctype: { type: 'string', short: 'd' },
+  'out-file': { type: 'string', short: 'o' },
+  'safe-mode': { type: 'string', short: 'S' },
+  embedded: { type: 'boolean', short: 'e' },
+  'no-header-footer': { type: 'boolean', short: 's' },
+  'section-numbers': { type: 'boolean', short: 'n' },
+  'base-dir': { type: 'string', short: 'B' },
+  'destination-dir': { type: 'string', short: 'D' },
+  'failure-level': { type: 'string' },
+  quiet: { type: 'boolean', short: 'q' },
+  trace: { type: 'boolean' },
+  verbose: { type: 'boolean', short: 'v' },
+  timings: { type: 'boolean', short: 't' },
+  attribute: { type: 'string', short: 'a', multiple: true },
+  require: { type: 'string', short: 'r', multiple: true },
+  version: { type: 'boolean', short: 'V' },
+  help: { type: 'boolean', short: 'h' },
+  'template-require': { type: 'string' },
+  watch: { type: 'boolean', short: 'w' },
+  preview: { type: 'boolean' },
+}
+
+function buildAsciidoctorOptions(args, extraAttributes = []) {
+  const attributes = [...extraAttributes]
+  if (args['section-numbers']) {
+    attributes.push('sectnums')
+  }
+  if (args.attribute) {
+    attributes.push(...args.attribute)
+  }
+  const quiet = args.quiet || false
+  const verbose = args.verbose || false
+  const verboseMode = quiet ? 0 : verbose ? 2 : 1
+  const embedded =
+    args.embedded === true || args['no-header-footer'] === true || false
+
+  const options = {
+    safe: args['safe-mode'] || 'unsafe',
+    standalone: !embedded,
+    verbose: verboseMode,
+    timings: args.timings || false,
+    trace: args.trace || false,
+    attributes,
+    mkdirs: true,
+  }
+  if (args.doctype) options.doctype = args.doctype
+  if (args.backend) options.backend = args.backend
+  if (args['base-dir'] != null) options.base_dir = args['base-dir']
+  if (args['destination-dir'] != null) options.to_dir = args['destination-dir']
+
+  const outFile = args['out-file']
+  if (outFile === '') {
+    options.to_file = process.stdout
+  } else if (outFile != null) {
+    options.to_file = outFile
+  }
+  return options
+}
+
+async function convertFiles(files, args, asciidoctorOptions, verbose, preview) {
   for (const file of files) {
     if (verbose) {
       console.log(`converting file ${file.contents ? '-' : file.path}`)
     }
     await converter.convert(
-      processor,
       file,
-      options,
-      argv.timings,
-      argv.watch,
+      asciidoctorOptions,
+      args.timings,
+      args.watch,
       preview,
     )
   }
@@ -25,68 +158,77 @@ async function convertFiles(files, argv, options, verbose, preview) {
 
 class PdfOptions {
   constructor() {
-    const defaultOptions = {
-      attributes: ['env-web-pdf', 'env=web-pdf'],
-    }
-    this.options = new Options(defaultOptions)
-      .addOption('template-require', {
-        describe: 'require the specified template script',
-        type: 'string',
-      })
-      .addOption('watch', {
-        alias: 'w',
-        default: false,
-        describe: 'enable watch mode',
-        type: 'boolean',
-      })
-      .addOption('preview', {
-        default: false,
-        describe:
-          'open the otherwise headless browser for inspecting the generated HTML document (before it gets converted to PDF)',
-        type: 'boolean',
-      })
+    this._defaultAttributes = ['env-web-pdf', 'env=web-pdf']
   }
 
   parse(argv) {
-    return this.options.parse(argv)
+    const processArgs = argv.slice(2)
+    let parsed
+    try {
+      parsed = parseArgs({
+        args: processArgs,
+        options: CLI_OPTIONS,
+        allowPositionals: true,
+      })
+    } catch (err) {
+      console.error(`Error: ${err.message}`)
+      process.exit(1)
+    }
+    const { values, positionals } = parsed
+    const stdin =
+      positionals.length === 0 && processArgs[processArgs.length - 1] === '-'
+    if (stdin && values['out-file'] == null) {
+      values['out-file'] = ''
+    }
+    const asciidoctorOptions = buildAsciidoctorOptions(
+      values,
+      this._defaultAttributes,
+    )
+    return {
+      argv,
+      args: { ...values, files: positionals },
+      options: asciidoctorOptions,
+      stdin,
+    }
   }
 }
 
-class PdfInvoker extends Invoker {
+class PdfInvoker {
+  constructor(options) {
+    this.options = options
+  }
+
   async invoke() {
     const cliOptions = this.options
     const processArgs = cliOptions.argv.slice(2)
     const { args } = cliOptions
-    const {
-      verbose,
-      version,
-      files,
-      watch,
-      'template-require': templateRequireLib,
-      preview,
-    } = args
-    if (version || (verbose && processArgs.length === 1)) {
-      this.showVersion()
+    const { verbose, version, files, watch, preview } = args
+    const templateRequireLib = args['template-require']
+
+    if (args.help) {
+      console.log(helpString())
       return { exit: true }
     }
+    if (version || (verbose && processArgs.length === 1)) {
+      console.log(versionString())
+      return { exit: true }
+    }
+
     let templates
     if (templateRequireLib) {
-      templates = Invoker.requireLibrary(templateRequireLib)
+      templates = requireLibrary(templateRequireLib)
     } else {
       templates = require('./document/document-converter').templates
     }
-    converter.registerTemplateConverter(processor, templates)
-    Invoker.prepareProcessor(args, processor)
+    converter.registerTemplateConverter(templates)
+    prepareProcessor(args)
+
     const asciidoctorOptions = cliOptions.options
+
     if (cliOptions.stdin) {
-      const fictiveInputFile = `${asciidoctorOptions.base_dir || asciidoctorOptions.attributes.docdir || process.cwd()}/asciidoctor-pdf-stdin.adoc`
-      const data = await Invoker.readFromStdin()
-      const fileObjects = [
-        {
-          path: fictiveInputFile,
-          contents: data,
-        },
-      ]
+      const fictiveInputFile = `${asciidoctorOptions.base_dir || process.cwd()}/asciidoctor-pdf-stdin.adoc`
+      const data = await readFromStdin()
+      const fileObjects = [{ path: fictiveInputFile, contents: data }]
       await convertFiles(
         fileObjects,
         args,
@@ -106,12 +248,12 @@ class PdfInvoker extends Invoker {
       )
       if (watch) {
         const watchFiles = files.map((file) => {
-          const dirname = path.dirname(file)
-          const allSubdirPath = path.join(dirname, '**')
+          const dirname = ospath.dirname(file)
+          const allSubdirPath = ospath.join(dirname, '**')
           return [
-            path.join(allSubdirPath, '*.css'),
-            path.join(allSubdirPath, '*.js'),
-            path.join(allSubdirPath, '*.adoc'),
+            ospath.join(allSubdirPath, '*.css'),
+            ospath.join(allSubdirPath, '*.js'),
+            ospath.join(allSubdirPath, '*.adoc'),
             file,
           ]
         })
@@ -120,9 +262,9 @@ class PdfInvoker extends Invoker {
         )
         chokidar
           .watch(watchFiles, { ignored: /(^|[/\\])\../ })
-          .on('change', async (path) => {
+          .on('change', async (changedPath) => {
             if (verbose) {
-              console.log(`  file changed ${path}`)
+              console.log(`  file changed ${changedPath}`)
             }
             try {
               const hasQueuedEvents = await processorLock.acquire()
@@ -144,18 +286,13 @@ class PdfInvoker extends Invoker {
         return { exit: true }
       }
     } else {
-      this.showHelp()
+      console.log(helpString())
       return { exit: true }
     }
-  }
-
-  version() {
-    return `Asciidoctor Web PDF ${pkg.version} using ${super.version()}`
   }
 }
 
 module.exports = {
   PdfOptions,
   PdfInvoker,
-  processor,
 }

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -1,4 +1,10 @@
-/* global Opal */
+const {
+  convert: asciidoctorConvert,
+  convertFile: asciidoctorConvertFile,
+  Html5Converter,
+  ConverterFactory,
+  Timings,
+} = require('@asciidoctor/core')
 const { PDFDocument } = require('pdf-lib')
 const util = require('node:util')
 const fsExtra = require('fs-extra')
@@ -10,21 +16,27 @@ const { addMetadata } = require('./metadata')
 
 const browserInstance = new Browser()
 
-function registerTemplateConverter(processor, templates) {
+function registerTemplateConverter(templates) {
   class TemplateConverter {
     constructor() {
-      this.baseConverter = processor.Html5Converter.create()
+      this.baseConverter = new Html5Converter('html5')
       this.templates = templates
       this.backendTraits = {
         basebackend: 'html',
         outfilesuffix: '.pdf',
         htmlsyntax: 'html',
-        supports_templates: true,
+        supportsTemplates: true,
       }
     }
 
+    handles(transform) {
+      return (
+        transform in this.templates || this.baseConverter.handles(transform)
+      )
+    }
+
     convert(node, transform, opts) {
-      const template = this.templates[transform || node.node_name]
+      const template = this.templates[transform || node.nodeName]
       if (template) {
         return template(node, this.baseConverter)
       }
@@ -32,10 +44,10 @@ function registerTemplateConverter(processor, templates) {
     }
   }
 
-  processor.ConverterFactory.register(new TemplateConverter(), ['html5'])
+  ConverterFactory.register(new TemplateConverter(), ['html5'])
 }
 
-async function convert(processor, inputFile, options, timings, watch, preview) {
+async function convert(inputFile, options, timings, watch, preview) {
   const tempFile = getTemporaryHtmlFile(inputFile.path, options)
   let workingDir
   if (options.to_dir) {
@@ -51,7 +63,7 @@ async function convert(processor, inputFile, options, timings, watch, preview) {
   let outputFile = path.join(workingDir, `${inputFilenameWithoutExt}.pdf`)
   let outputToStdout = false
   if (options.to_file) {
-    if (options.to_file !== Opal.gvars.stdout) {
+    if (options.to_file !== process.stdout) {
       await mkdirs(path.dirname(options.to_file))
       if (options.to_dir) {
         outputFile = path.join(options.to_dir, options.to_file)
@@ -67,18 +79,16 @@ async function convert(processor, inputFile, options, timings, watch, preview) {
   let timer
 
   if (timings) {
-    timer = processor.Timings.create()
+    timer = new Timings()
     instanceOptions.timings = timer
   }
 
   if (inputFile.contents) {
-    // data from stdin
-    doc = processor.convert(inputFile.contents, instanceOptions)
+    doc = await asciidoctorConvert(inputFile.contents, instanceOptions)
   } else {
-    doc = processor.convertFile(inputFile.path, instanceOptions)
+    doc = await asciidoctorConvertFile(inputFile.path, instanceOptions)
   }
 
-  // if (typeof timer !== 'undefined' && timer !== null) {
   if (timings) {
     timer.printReport(process.stderr, inputFile.contents ? '-' : inputFile.path)
   }
@@ -102,22 +112,20 @@ async function convert(processor, inputFile, options, timings, watch, preview) {
         preferCSSPageSize: true,
         timeout: printTimeout,
       }
-      const pdfWidth = doc.getAttributes()['pdf-width']
+      const pdfWidth = doc.attributes['pdf-width']
       if (pdfWidth) {
         pdfOptions.width = pdfWidth
       }
-      const pdfHeight = doc.getAttributes()['pdf-height']
+      const pdfHeight = doc.attributes['pdf-height']
       if (pdfHeight) {
         pdfOptions.height = pdfHeight
       }
-      const format = doc.getAttributes()['pdf-format']
+      const format = doc.attributes['pdf-format']
       if (format) {
-        pdfOptions.format = format // Paper format. If set, takes priority over width or height options. Defaults to 'Letter'.
+        pdfOptions.format = format
       }
 
       let pdf = await page.pdf(pdfOptions)
-      // Outline is not yet implemented in Chromium, so we add it manually here.
-      // https://bugs.chromium.org/p/chromium/issues/detail?id=840455
       let pdfDoc = await PDFDocument.load(pdf)
       pdfDoc = await addOutline(pdfDoc, doc)
       pdfDoc = await addMetadata(pdfDoc, doc)
@@ -127,7 +135,7 @@ async function convert(processor, inputFile, options, timings, watch, preview) {
           process.stdout.setDefaultEncoding('binary')
           process.stdout.write(Buffer.from(pdf).toString('binary'))
         } finally {
-          process.stdout.setDefaultEncoding('utf-8') // reset
+          process.stdout.setDefaultEncoding('utf-8')
         }
       } else {
         fsExtra.writeFileSync(outputFile, pdf)
@@ -158,7 +166,7 @@ function getTemporaryHtmlFile(inputFile, options) {
   const workingDir = path.dirname(inputFile)
   let baseFile = inputFile
   if (options.to_file) {
-    if (options.to_file !== Opal.gvars.stdout) {
+    if (options.to_file !== process.stdout) {
       baseFile = options.to_file
     }
   }

--- a/lib/converter.js
+++ b/lib/converter.js
@@ -1,22 +1,22 @@
-const {
-  convert: asciidoctorConvert,
-  convertFile: asciidoctorConvertFile,
-  Html5Converter,
+import path from 'node:path'
+import { promisify } from 'node:util'
+import {
+  convert as asciidoctorConvert,
+  convertFile as asciidoctorConvertFile,
   ConverterFactory,
+  Html5Converter,
   Timings,
-} = require('@asciidoctor/core')
-const { PDFDocument } = require('pdf-lib')
-const util = require('node:util')
-const fsExtra = require('fs-extra')
-const path = require('node:path')
-const mkdirs = util.promisify(fsExtra.mkdirs)
-const Browser = require('./browser.js')
-const { addOutline } = require('./outline.js')
-const { addMetadata } = require('./metadata')
+} from '@asciidoctor/core'
+import fsExtra from 'fs-extra'
+import { PDFDocument } from 'pdf-lib'
+import Browser from './browser.js'
+import { addMetadata } from './metadata.js'
+import { addOutline } from './outline.js'
 
+const mkdirs = promisify(fsExtra.mkdirs)
 const browserInstance = new Browser()
 
-function registerTemplateConverter(templates) {
+export function registerTemplateConverter(templates) {
   class TemplateConverter {
     constructor() {
       this.baseConverter = new Html5Converter('html5')
@@ -47,7 +47,7 @@ function registerTemplateConverter(templates) {
   ConverterFactory.register(new TemplateConverter(), ['html5'])
 }
 
-async function convert(inputFile, options, timings, watch, preview) {
+export async function convert(inputFile, options, timings, watch, preview) {
   const tempFile = getTemporaryHtmlFile(inputFile.path, options)
   let workingDir
   if (options.to_dir) {
@@ -62,16 +62,14 @@ async function convert(inputFile, options, timings, watch, preview) {
   )
   let outputFile = path.join(workingDir, `${inputFilenameWithoutExt}.pdf`)
   let outputToStdout = false
-  if (options.to_file) {
-    if (options.to_file !== process.stdout) {
-      await mkdirs(path.dirname(options.to_file))
-      if (options.to_dir) {
-        outputFile = path.join(options.to_dir, options.to_file)
-      } else {
-        outputFile = options.to_file
-      }
+  if (options.to_file === false) {
+    outputToStdout = true
+  } else if (options.to_file) {
+    await mkdirs(path.dirname(options.to_file))
+    if (options.to_dir) {
+      outputFile = path.join(options.to_dir, options.to_file)
     } else {
-      outputToStdout = true
+      outputFile = options.to_file
     }
   }
   const instanceOptions = Object.assign({}, options, { to_file: tempFile })
@@ -93,13 +91,6 @@ async function convert(inputFile, options, timings, watch, preview) {
     timer.printReport(process.stderr, inputFile.contents ? '-' : inputFile.path)
   }
 
-  const puppeteerConfig = {
-    headless: !preview,
-    args: ['--no-sandbox', '--allow-file-access-from-files'],
-  }
-  if (preview) {
-    Object.assign(puppeteerConfig, { defaultViewport: null })
-  }
   try {
     const page = await browserInstance.goto(`file://${tempFile}`, preview)
     const puppeteerDefaultTimeout = process.env.PUPPETEER_DEFAULT_TIMEOUT
@@ -165,10 +156,8 @@ async function convert(inputFile, options, timings, watch, preview) {
 function getTemporaryHtmlFile(inputFile, options) {
   const workingDir = path.dirname(inputFile)
   let baseFile = inputFile
-  if (options.to_file) {
-    if (options.to_file !== process.stdout) {
-      baseFile = options.to_file
-    }
+  if (options.to_file && options.to_file !== false) {
+    baseFile = options.to_file
   }
   const inputFilenameWithoutExt = path.basename(
     baseFile,
@@ -183,9 +172,4 @@ function getTemporaryHtmlFile(inputFile, options) {
     )
   }
   return tempFile
-}
-
-module.exports = {
-  convert,
-  registerTemplateConverter,
 }

--- a/lib/document/document-converter.js
+++ b/lib/document/document-converter.js
@@ -1,6 +1,6 @@
-/* global Opal */
 const fs = require('node:fs')
 const ospath = require('node:path')
+const { Html5Converter } = require('@asciidoctor/core')
 
 const isSea = (() => {
   try {
@@ -52,7 +52,7 @@ const DropAnchorRx = /<(?:a[^>+]+|\/a)>/
 class DocumentPDFConverter {
   /* eslint-disable camelcase */
   constructor() {
-    this.baseConverter = Opal.Asciidoctor.Html5Converter.create()
+    this.baseConverter = new Html5Converter('html5')
     // <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css"/>
     this.linkStylesheet = /(<link rel="stylesheet"[^>]*\/>)/g
     this.stemContent = require('./stem')
@@ -99,7 +99,7 @@ class DocumentPDFConverter {
   }
 
   convert(node, transform, opts) {
-    const name = `convert_${transform || node.node_name}`
+    const name = `convert_${transform || node.nodeName}`
     const convertFunction = this[name]
     if (convertFunction) {
       return convertFunction.call(this, node)
@@ -107,17 +107,17 @@ class DocumentPDFConverter {
     return this.baseConverter.convert(node, transform, opts)
   }
 
-  convert_document(node, opts = {}) {
+  async convert_document(node, opts = {}) {
     const cdnBaseUrl = `${this.assetUriScheme(node)}//cdnjs.cloudflare.com/ajax/libs`
     const linkcss = node.isAttribute('linkcss')
     let contentHTML = ''
-    const content = node.getContent()
+    const content = await node.getContent()
     if (content && content.trim() !== '') {
       contentHTML = `<div id="content" class="content">
 ${content}
 </div>`
     }
-    const syntaxHighlighter = node.$syntax_highlighter()
+    const syntaxHighlighter = node.syntaxHighlighter
     const bodyAttrs = node.getId() ? [`id="${node.getId()}"`] : []
     let classes
     if (
@@ -141,6 +141,13 @@ ${content}
     if (node.hasAttribute('max-width')) {
       bodyAttrs.push(`style="max-width: ${node.getAttribute('max-width')};"`)
     }
+    const [docinfoHead, docinfoHeader, docinfoRunning, docinfoFooter] =
+      await Promise.all([
+        this.docinfoContent(node, 'head', '-pdf.html'),
+        this.docinfoContent(node, 'header', '-pdf.html'),
+        this.docinfoContent(node, 'running', '-pdf.html'),
+        this.docinfoContent(node, 'footer', '-pdf.html'),
+      ])
     return `<!DOCTYPE html>
 <html dir="ltr"${this.langAttr(node)}>
 <head>
@@ -150,11 +157,11 @@ ${this.fontAwesomeStyle(node)}
 ${this.styles(node)}
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 ${this.syntaxHighlighterHead(node, syntaxHighlighter, { cdn_base_url: cdnBaseUrl, linkcss: linkcss, self_closing_tag_slash: '/' })}
-${this.docinfoContent(node, 'head', '-pdf.html')}
+${docinfoHead}
 </head>
 <body ${bodyAttrs.join(' ')}>
-${this.docinfoContent(node, 'header', '-pdf.html')}
-${this.docinfoContent(node, 'running', '-pdf.html')}
+${docinfoHeader}
+${docinfoRunning}
 ${this.titlePage(node)}
 ${this.outline(node, opts)}
 ${this.tocHeader(node, opts)}
@@ -167,7 +174,7 @@ ${this.pagedContent}
 ${this.pagedRendering}
 ${this.repeatTableElementsContent}
 </script>
-${this.docinfoContent(node, 'footer', '-pdf.html')}
+${docinfoFooter}
 </body>
 </html>`
   }
@@ -178,11 +185,11 @@ ${this.docinfoContent(node, 'footer', '-pdf.html')}
     }
     const sectnumlevels =
       opts.sectnumlevels ||
-      parseInt(node.getDocument().getAttributes().sectnumlevels, 10) ||
+      parseInt(node.getDocument().attributes.sectnumlevels, 10) ||
       3
     const toclevels =
       opts.toclevels ||
-      parseInt(node.getDocument().getAttributes().toclevels, 10) ||
+      parseInt(node.getDocument().attributes.toclevels, 10) ||
       2
     const sections = node.getSections()
     // FIXME top level is incorrect if a multipart book starts with a special section defined at level 0
@@ -196,20 +203,16 @@ ${this.docinfoContent(node, 'footer', '-pdf.html')}
       } else if (section.isNumbered() && slevel <= sectnumlevels) {
         if (slevel < 2 && node.getDocument().getDoctype() === 'book') {
           if (section.getSectionName() === 'chapter') {
-            const signifier = node.getDocument().getAttributes()[
-              'chapter-signifier'
-            ]
-            stitle = `${signifier ? `"${signifier} "` : ''}${section.$sectnum()} ${section.getTitle()}`
+            const signifier = node.getDocument().attributes['chapter-signifier']
+            stitle = `${signifier ? `"${signifier} "` : ''}${section.sectnum()} ${section.getTitle()}`
           } else if (section.getSectionName() === 'part') {
-            const signifier = node.getDocument().getAttributes()[
-              'part-signifier'
-            ]
-            stitle = `${signifier ? `"${signifier} "` : ''}${section.$sectnum(Opal.nil, ':')} ${section.getTitle()}`
+            const signifier = node.getDocument().attributes['part-signifier']
+            stitle = `${signifier ? `"${signifier} "` : ''}${section.sectnum('.', ':')} ${section.getTitle()}`
           } else {
-            stitle = `${section.$sectnum()} ${section.getTitle()}`
+            stitle = `${section.sectnum()} ${section.getTitle()}`
           }
         } else {
-          stitle = `${section.$sectnum()} ${section.getTitle()}`
+          stitle = `${section.sectnum()} ${section.getTitle()}`
         }
       } else {
         stitle = section.getTitle()
@@ -237,7 +240,7 @@ ${this.docinfoContent(node, 'footer', '-pdf.html')}
     return result.join('\n')
   }
 
-  convert_admonition(node) {
+  async convert_admonition(node) {
     const idAttribute = node.getId() ? ` id="${node.getId()}"` : ''
     const name = node.getAttribute('name')
     const titleElement = node.getTitle()
@@ -270,6 +273,7 @@ ${this.docinfoContent(node, 'footer', '-pdf.html')}
     } else {
       label = `<div class="title">${node.getAttribute('textlabel')}</div>`
     }
+    const content = await node.getContent()
     return `<div${idAttribute} class="admonitionblock ${name}${node.getRole() ? node.getRole() : ''}">
 <table>
 <tr>
@@ -277,7 +281,7 @@ ${this.docinfoContent(node, 'footer', '-pdf.html')}
 ${label}
 </td>
 <td class="content">
-${titleElement}${node.getContent()}
+${titleElement}${content}
 </td>
 </tr>
 </table>
@@ -332,11 +336,11 @@ ${titleElement}${node.getContent()}
         return icon.html
       }
     } else {
-      return this.baseConverter.$convert_inline_image(node)
+      return this.baseConverter.convert(node, 'inline_image')
     }
   }
 
-  convert_colist(node) {
+  async convert_colist(node) {
     const result = []
     const idAttribute = node.getId() ? ` id="${node.getId()}"` : ''
     let classes = ['colist']
@@ -357,28 +361,28 @@ ${titleElement}${node.getContent()}
     ) {
       result.push('<table>')
       let num = 0
-      const svgIcons = this.isSvgIconEnabled(node)
-      let numLabel
-      node.getItems().forEach((item) => {
+      const _svgIcons = this.isSvgIconEnabled(node)
+      for (const item of node.getItems()) {
         num += 1
-        if (svgIcons) {
-          numLabel = `<i class="conum" data-value="${num}"></i><b>${num}</b>`
-        } else {
-          numLabel = `<i class="conum" data-value="${num}"></i><b>${num}</b>`
-        }
+        const numLabel = `<i class="conum" data-value="${num}"></i><b>${num}</b>`
+        const itemContent = item.hasBlocks()
+          ? `\n ${await item.getContent()}`
+          : ''
         result.push(`<tr>
           <td>${numLabel}</td>
-          <td>${item.getText()}${item['$blocks?']() ? `\n ${item.getContent()}` : ''}</td>
+          <td>${item.getText()}${itemContent}</td>
           </tr>`)
-      })
+      }
       result.push('</table>')
     } else {
       result.push('<ol>')
-
-      node.getItems().forEach((item) => {
+      for (const item of node.getItems()) {
+        const itemContent = item.hasBlocks()
+          ? `\n ${await item.getContent()}`
+          : ''
         result.push(`<li>
-<p>${item.getText()}</p>${item['$blocks?']() ? `\n ${item.getContent()}` : ''}`)
-      })
+<p>${item.getText()}</p>${itemContent}`)
+      }
       result.push('</ol>')
     }
     result.push('</div>')
@@ -390,7 +394,7 @@ ${titleElement}${node.getContent()}
     return '<div class="page-break" style="break-after: page;"></div>'
   }
 
-  convert_preamble(node, opts = {}) {
+  async convert_preamble(node, opts = {}) {
     const doc = node.getDocument()
     let toc
     if (
@@ -406,16 +410,17 @@ ${this.convert_outline(doc, opts)}
     } else {
       toc = ''
     }
+    const content = await node.getContent()
     return `<div id="preamble">
 <div class="sectionbody">
-${node.getContent()}
+${content}
 </div>${toc}
 </div>`
   }
 
-  convert_inline_footnote(node) {
+  async convert_inline_footnote(node) {
     if (node.getDocument().isAttribute('nofootnotes')) {
-      return this.baseConverter.$convert_inline_footnote(node)
+      return this.baseConverter.convert(node, 'inline_footnote')
     }
     const index = node.getAttribute('index')
     const text = node.getText()
@@ -431,7 +436,25 @@ ${node.getContent()}
     const paths = [cwd, ospath.dirname(__dirname)].map((start) =>
       ospath.join(start, 'node_modules'),
     )
-    return require.resolve(requirePath, { paths })
+    try {
+      return require.resolve(requirePath, { paths })
+    } catch (e) {
+      if (e.code === 'ERR_PACKAGE_PATH_NOT_EXPORTED') {
+        // Package has strict exports — resolve by walking node_modules directly
+        const parts = requirePath.split('/')
+        const packageName = requirePath.startsWith('@')
+          ? `${parts[0]}/${parts[1]}`
+          : parts[0]
+        const subPath = requirePath.slice(packageName.length + 1)
+        for (const nodeModulesDir of paths) {
+          const candidate = ospath.join(nodeModulesDir, packageName, subPath)
+          if (fs.existsSync(candidate)) {
+            return candidate
+          }
+        }
+      }
+      throw e
+    }
   }
 
   styles(node) {
@@ -532,32 +555,19 @@ ${faDom.css()}
     return ''
   }
 
-  docinfoContent(node, docinfoLocation, suffix) {
-    const docinfoContent = node.getDocinfo(docinfoLocation, suffix)
-    if (docinfoContent) {
-      return docinfoContent
-    }
-    return ''
+  async docinfoContent(node, docinfoLocation, suffix) {
+    const content = await node.getDocinfo(docinfoLocation, suffix)
+    return content || ''
   }
 
   syntaxHighlighterHead(node, syntaxHighlighter, attrs) {
     let header = ''
-    if (
-      syntaxHighlighter !== Opal.nil &&
-      syntaxHighlighter['$docinfo?']('head')
-    ) {
-      header = syntaxHighlighter.$docinfo('head', node, Opal.hash(attrs))
+    if (syntaxHighlighter?.hasDocinfo('head')) {
+      header = syntaxHighlighter.docinfo('head', node, attrs)
     }
-    if (
-      syntaxHighlighter !== Opal.nil &&
-      syntaxHighlighter['$docinfo?']('footer')
-    ) {
+    if (syntaxHighlighter?.hasDocinfo('footer')) {
       // reordering all link elements from footer to header, as pagedjs would otherwise render them too late in the process
-      const footer = syntaxHighlighter.$docinfo(
-        'footer',
-        node,
-        Opal.hash(attrs),
-      )
+      const footer = syntaxHighlighter.docinfo('footer', node, attrs)
       const matches = footer.match(this.linkStylesheet)
       if (matches !== null) {
         matches.forEach((element) => {
@@ -570,12 +580,9 @@ ${faDom.css()}
 
   syntaxHighlighterFooter(node, syntaxHighlighter, attrs) {
     let footer = ''
-    if (
-      syntaxHighlighter !== Opal.nil &&
-      syntaxHighlighter['$docinfo?']('footer')
-    ) {
+    if (syntaxHighlighter?.hasDocinfo('footer')) {
       // skip all link elements in the footer as they are re-ordered to the header by syntaxHighlighterHead()
-      footer = syntaxHighlighter.$docinfo('footer', node, Opal.hash(attrs))
+      footer = syntaxHighlighter.docinfo('footer', node, attrs)
       footer = footer.replace(this.linkStylesheet, '')
     }
     return footer
@@ -609,9 +616,10 @@ ${faDom.css()}
     if (node.getDocumentTitle()) {
       const doc = node.getDocument()
       if (this.hasTitlePage(doc)) {
+        const author = doc.getAuthor()
         return `<div id="cover" class="title-page front-matter">
   <h1>${node.getDocumentTitle()}</h1>
-  <h2>${node.getDocument().getAuthor()}</h2>
+  ${author ? `<h2>${author}</h2>` : ''}
 </div>`
       }
       return `<div class="title-document">

--- a/lib/document/document-converter.js
+++ b/lib/document/document-converter.js
@@ -1,6 +1,27 @@
-const fs = require('node:fs')
-const ospath = require('node:path')
-const { Html5Converter } = require('@asciidoctor/core')
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import ospath from 'node:path'
+import { Html5Converter } from '@asciidoctor/core'
+import {
+  dom as faDom,
+  icon as faIcon,
+  layer as faLayer,
+  library as faLibrary,
+} from '@fortawesome/fontawesome-svg-core'
+import { fab } from '@fortawesome/free-brands-svg-icons'
+import { faLightbulb, far } from '@fortawesome/free-regular-svg-icons'
+import {
+  faCircle,
+  faExclamationCircle,
+  faExclamationTriangle,
+  faHandPaper,
+  faInfoCircle,
+  faQuestionCircle,
+  fas,
+} from '@fortawesome/free-solid-svg-icons'
+import stemContent from './stem.js'
+
+const require = createRequire(import.meta.url)
 
 const isSea = (() => {
   try {
@@ -9,24 +30,6 @@ const isSea = (() => {
     return false
   }
 })()
-
-const {
-  layer: faLayer,
-  icon: faIcon,
-  dom: faDom,
-  library: faLibrary,
-} = require('@fortawesome/fontawesome-svg-core')
-const {
-  faCircle,
-  faInfoCircle,
-  faExclamationCircle,
-  faQuestionCircle,
-  faExclamationTriangle,
-  faHandPaper,
-  fas,
-} = require('@fortawesome/free-solid-svg-icons')
-const { faLightbulb, far } = require('@fortawesome/free-regular-svg-icons')
-const { fab } = require('@fortawesome/free-brands-svg-icons')
 faLibrary.add(fas, far, fab)
 
 const faDefaultIcon = faIcon(faQuestionCircle)
@@ -55,10 +58,10 @@ class DocumentPDFConverter {
     this.baseConverter = new Html5Converter('html5')
     // <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css"/>
     this.linkStylesheet = /(<link rel="stylesheet"[^>]*\/>)/g
-    this.stemContent = require('./stem')
+    this.stemContent = stemContent
     const scriptsDir = isSea
       ? ospath.join(ospath.dirname(process.execPath), 'scripts')
-      : __dirname
+      : import.meta.dirname
     this.repeatTableElementsContent = fs.readFileSync(
       ospath.join(scriptsDir, 'repeating-table-elements.js'),
       'utf8',
@@ -75,7 +78,7 @@ class DocumentPDFConverter {
     )
     const stylesDir = isSea
       ? ospath.join(ospath.dirname(process.execPath), 'css')
-      : ospath.resolve(`${__dirname}/../../css`)
+      : ospath.resolve(`${import.meta.dirname}/../../css`)
     this.asciidoctorStyleContent = fs.readFileSync(
       `${stylesDir}/asciidoctor.css`,
       'utf8',
@@ -433,7 +436,7 @@ ${content}
 
   resolveStylesheet(requirePath, cwd = process.cwd()) {
     // NOTE appending node_modules prevents require from looking elsewhere before looking in these paths
-    const paths = [cwd, ospath.dirname(__dirname)].map((start) =>
+    const paths = [cwd, ospath.dirname(import.meta.dirname)].map((start) =>
       ospath.join(start, 'node_modules'),
     )
     try {
@@ -661,8 +664,9 @@ ${this.convert_outline(node, opts)}
 
 const instance = new DocumentPDFConverter()
 
-module.exports = DocumentPDFConverter
-module.exports.templates = {
+export default DocumentPDFConverter
+
+export const templates = {
   document: (node, opts) => instance.convert_document(node, opts),
   convert_outline: (node, opts) => instance.convert_outline(node, opts),
   admonition: (node) => instance.convert_admonition(node),

--- a/lib/document/stem.js
+++ b/lib/document/stem.js
@@ -26,7 +26,7 @@ const mathjaxFileUrl = isPkg
 module.exports = {
   content: (node) => {
     // logic borrowed from Asciidoctor HTML5 converter
-    if (node.getAttribute('stem') !== undefined) {
+    if (node.getAttribute('stem') != null) {
       let eqnumsValue = node.getAttribute('eqnums', 'none')
       if (eqnumsValue === '') {
         eqnumsValue = 'ams'

--- a/lib/document/stem.js
+++ b/lib/document/stem.js
@@ -1,5 +1,8 @@
-const fileUrl = require('file-url')
-const ospath = require('node:path')
+import { createRequire } from 'node:module'
+import ospath from 'node:path'
+import fileUrl from 'file-url'
+
+const require = createRequire(import.meta.url)
 
 const isSea = (() => {
   try {
@@ -23,9 +26,8 @@ const mathjaxFileUrl = isPkg
       )
     : fileUrl(require.resolve('mathjax/es5/tex-chtml-full.js'))
 
-module.exports = {
+export default {
   content: (node) => {
-    // logic borrowed from Asciidoctor HTML5 converter
     if (node.getAttribute('stem') != null) {
       let eqnumsValue = node.getAttribute('eqnums', 'none')
       if (eqnumsValue === '') {
@@ -76,9 +78,6 @@ module.exports = {
     }
   })
 
-  // defer relayouting by 'Paged' until 'MathJax' rendering is complete
-  // otherwise formulas wouldn't be replaced and content height can't be calculated by 'Paged'
-  // 'MathJax' needs to be loaded before 'Paged' to make this work
   window.PagedConfig = window.PagedConfig || {}
   window.PagedConfig.before = () => mathJaxReadyPromise
 })()

--- a/lib/lock.js
+++ b/lib/lock.js
@@ -1,6 +1,6 @@
-const { EventEmitter } = require('node:events')
+import { EventEmitter } from 'node:events'
 
-class Lock {
+export default class Lock {
   constructor() {
     this._queueSize = 0
     this._locked = false
@@ -38,4 +38,3 @@ class Lock {
     setImmediate(() => this._ee.emit('release'))
   }
 }
-module.exports = Lock

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -1,7 +1,4 @@
-import { createRequire } from 'node:module'
-
-const require = createRequire(import.meta.url)
-const pkg = require('../package.json')
+import pkg from '../package.json' with { type: 'json' }
 
 export const addMetadata = async (pdfDoc, doc) => {
   let modificationDate, creationDate, creator

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -1,6 +1,9 @@
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
 const pkg = require('../package.json')
 
-const addMetadata = async (pdfDoc, doc) => {
+export const addMetadata = async (pdfDoc, doc) => {
   let modificationDate, creationDate, creator
   if (doc.hasAttribute('reproducible')) {
     const date = new Date()
@@ -36,8 +39,4 @@ const addMetadata = async (pdfDoc, doc) => {
     pdfDoc.setLanguage(lang)
   }
   return pdfDoc
-}
-
-module.exports = {
-  addMetadata,
 }

--- a/lib/outline.js
+++ b/lib/outline.js
@@ -1,5 +1,5 @@
-const { PDFDict, PDFName, PDFNumber, PDFHexString } = require('pdf-lib')
-const { decode: htmlEntitiesDecode } = require('html-entities')
+import { decode as htmlEntitiesDecode } from 'html-entities'
+import { PDFDict, PDFHexString, PDFName, PDFNumber } from 'pdf-lib'
 
 const SanitizeXMLRx = /<[^>]+>/g
 
@@ -95,7 +95,7 @@ This likely happened because an anchor link contained an umlaut (https://bugs.ch
   }
 }
 
-async function addOutline(pdfDoc, doc) {
+export async function addOutline(pdfDoc, doc) {
   const depth = doc.getAttribute('toclevels') || 2
   const context = pdfDoc.context
   const outlineRef = context.nextRef()
@@ -120,8 +120,4 @@ async function addOutline(pdfDoc, doc) {
 
   pdfDoc.catalog.set(PDFName.of('Outlines'), outlineRef)
   return pdfDoc
-}
-
-module.exports = {
-  addOutline,
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@fortawesome/free-regular-svg-icons": "6.2.1",
         "@fortawesome/free-solid-svg-icons": "6.2.1",
         "@ggrossetie/pagedjs": "0.2.0-next.1623590414",
+        "asciidoctor": ">= 4.0.0-alpha.5 < 5",
         "chokidar": "~3.5",
         "file-url": "~3.0",
         "fs-extra": "~11.1.0",
@@ -27,10 +28,9 @@
         "asciidoctor-web-pdf": "bin/asciidoctor-web-pdf"
       },
       "devDependencies": {
-        "@asciidoctor/core": "^4.0.0-alpha.5",
         "@biomejs/biome": "2.4.15",
+        "@puppeteer/browsers": "~3.0",
         "archiver": "~8.0",
-        "asciidoctor": "^4.0.0-alpha.5",
         "esbuild": "0.28.0",
         "node-html-parser": "~7.1",
         "nunjucks": "~3.2",
@@ -38,18 +38,17 @@
         "postject": "1.0.0-alpha.6"
       },
       "engines": {
-        "node": ">=18",
+        "node": ">=21",
         "npm": ">=8.0.0"
       },
       "peerDependencies": {
-        "@asciidoctor/core": "^4.0.0-alpha.4"
+        "asciidoctor": ">= 4.0.0-alpha.5 < 5"
       }
     },
     "node_modules/@asciidoctor/core": {
       "version": "4.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.5.tgz",
       "integrity": "sha512-xwR3hyqmXgZ9W0um4GKveKWY9rjLTpkuu2TINC2m9qXb41X15wqYlWcmMRtdqywawYRsf6kaxR47mHqJpVNu4A==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -925,7 +924,6 @@
       "version": "4.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.0-alpha.5.tgz",
       "integrity": "sha512-6mh4HvwG+mxrRbTTsAY8auqGBfo0RucX7eLAcVQlJ9Ez4CZT43oiaCD0TRos/CA7Tri/sIlDmv3u4mdqlaXcAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asciidoctor/core": "4.0.0-alpha.5"
@@ -2354,8 +2352,7 @@
     "@asciidoctor/core": {
       "version": "4.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.5.tgz",
-      "integrity": "sha512-xwR3hyqmXgZ9W0um4GKveKWY9rjLTpkuu2TINC2m9qXb41X15wqYlWcmMRtdqywawYRsf6kaxR47mHqJpVNu4A==",
-      "dev": true
+      "integrity": "sha512-xwR3hyqmXgZ9W0um4GKveKWY9rjLTpkuu2TINC2m9qXb41X15wqYlWcmMRtdqywawYRsf6kaxR47mHqJpVNu4A=="
     },
     "@babel/polyfill": {
       "version": "7.12.1",
@@ -2794,7 +2791,6 @@
       "version": "4.0.0-alpha.5",
       "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.0-alpha.5.tgz",
       "integrity": "sha512-6mh4HvwG+mxrRbTTsAY8auqGBfo0RucX7eLAcVQlJ9Ez4CZT43oiaCD0TRos/CA7Tri/sIlDmv3u4mdqlaXcAw==",
-      "dev": true,
       "requires": {
         "@asciidoctor/core": "4.0.0-alpha.5"
       }
@@ -2809,13 +2805,15 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "bare-events": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "bare-fs": {
       "version": "4.7.1",
@@ -3737,7 +3735,8 @@
     "ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "requires": {}
     },
     "y18n": {
       "version": "5.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0-alpha.16",
       "license": "MIT",
       "dependencies": {
-        "@asciidoctor/cli": "~3.5",
         "@fortawesome/fontawesome-svg-core": "6.2.1",
         "@fortawesome/free-brands-svg-icons": "6.2.1",
         "@fortawesome/free-regular-svg-icons": "6.2.1",
@@ -21,15 +20,14 @@
         "html-entities": "~2.3",
         "mathjax": "3.2.2",
         "pdf-lib": "~1.17",
-        "puppeteer": "25.1.0",
-        "yargs": "17.6.2"
+        "puppeteer": "25.1.0"
       },
       "bin": {
         "asciidoctor-pdf": "bin/asciidoctor-pdf",
         "asciidoctor-web-pdf": "bin/asciidoctor-web-pdf"
       },
       "devDependencies": {
-        "@asciidoctor/core": "~2.2",
+        "@asciidoctor/core": "^4.0.0-alpha.4",
         "@biomejs/biome": "2.4.15",
         "archiver": "~8.0",
         "esbuild": "0.28.0",
@@ -43,57 +41,17 @@
         "npm": ">=8.0.0"
       },
       "peerDependencies": {
-        "@asciidoctor/core": "~2.2"
-      }
-    },
-    "node_modules/@asciidoctor/cli": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/cli/-/cli-3.5.0.tgz",
-      "integrity": "sha512-/VMHXcZBnZ9vgWfmqk9Hu0x0gMjPLup0YGq/xA8qCQuk11kUIZNMVQwgSsIUzOEwJqIUD7CgncJdtfwv1Ndxuw==",
-      "dependencies": {
-        "yargs": "16.2.0"
-      },
-      "bin": {
-        "asciidoctor": "bin/asciidoctor",
-        "asciidoctorjs": "bin/asciidoctor"
-      },
-      "engines": {
-        "node": ">=8.11",
-        "npm": ">=5.0.0"
-      },
-      "peerDependencies": {
-        "@asciidoctor/core": "^2.0.0-rc.1"
-      }
-    },
-    "node_modules/@asciidoctor/cli/node_modules/yargs": {
-      "version": "16.2.0",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-      "dependencies": {
-        "cliui": "^7.0.2",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.0",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^20.2.2"
-      },
-      "engines": {
-        "node": ">=10"
+        "@asciidoctor/core": "^4.0.0-alpha.4"
       }
     },
     "node_modules/@asciidoctor/core": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.6.tgz",
-      "integrity": "sha512-TmB2K5UfpDpSbCNBBntXzKHcAk2EA3/P68jmWvmJvglVUdkO9V6kTAuXVe12+h6C4GK0ndwuCrHHtEVcL5t6pQ==",
-      "dependencies": {
-        "asciidoctor-opal-runtime": "0.3.3",
-        "unxhr": "1.0.1"
-      },
+      "version": "4.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.4.tgz",
+      "integrity": "sha512-MuP8DQq6W/y3SmsglF3FfN2qsafFWAaYkRzuATXuXN4fOxFVXETt1JmlLBPIMZM5uvd48IsFzv5Kb0cIQzRUoQ==",
+      "dev": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=8.11",
-        "npm": ">=5.0.0",
-        "yarn": ">=1.1.0"
+        "node": ">=24"
       }
     },
     "node_modules/@babel/polyfill": {
@@ -962,34 +920,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
-    "node_modules/asciidoctor-opal-runtime": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.3.tgz",
-      "integrity": "sha512-/CEVNiOia8E5BMO9FLooo+Kv18K4+4JBFRJp8vUy/N5dMRAg+fRNV4HA+o6aoSC79jVU/aT5XvUpxSxSsTS8FQ==",
-      "dependencies": {
-        "glob": "7.1.3",
-        "unxhr": "1.0.1"
-      },
-      "engines": {
-        "node": ">=8.11"
-      }
-    },
-    "node_modules/asciidoctor-opal-runtime/node_modules/glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -1010,11 +940,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "node_modules/bare-events": {
       "version": "2.8.3",
@@ -1148,16 +1073,6 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
-    "node_modules/brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "node_modules/braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -1252,16 +1167,6 @@
       "resolved": "https://registry.npmjs.org/clear-cut/-/clear-cut-2.0.2.tgz",
       "integrity": "sha512-WVgn/gSejQ+0aoR8ucbKIdo6icduPZW6AbWwyUmAUgxy63rUYjwa5rj/HeoNPhf0/XPrl82X8bO/hwBkSmsFtg=="
     },
-    "node_modules/cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1303,11 +1208,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "node_modules/core-js": {
       "version": "2.6.12",
@@ -1675,11 +1575,6 @@
         "node": ">=14.14"
       }
     },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1753,19 +1648,11 @@
       ],
       "license": "BSD-3-Clause"
     },
-    "node_modules/inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dependencies": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -1913,18 +1800,6 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
-    "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -2002,26 +1877,10 @@
         }
       }
     },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": {
-        "wrappy": "1"
-      }
-    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "node_modules/path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/pdf-lib": {
       "version": "1.17.1",
@@ -2390,14 +2249,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/unxhr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.0.1.tgz",
-      "integrity": "sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg==",
-      "engines": {
-        "node": ">=8.11"
-      }
-    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -2426,11 +2277,6 @@
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
       "version": "8.21.0",
@@ -2461,52 +2307,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/yargs/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/zip-stream": {
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
@@ -2533,38 +2333,11 @@
     }
   },
   "dependencies": {
-    "@asciidoctor/cli": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/cli/-/cli-3.5.0.tgz",
-      "integrity": "sha512-/VMHXcZBnZ9vgWfmqk9Hu0x0gMjPLup0YGq/xA8qCQuk11kUIZNMVQwgSsIUzOEwJqIUD7CgncJdtfwv1Ndxuw==",
-      "requires": {
-        "yargs": "16.2.0"
-      },
-      "dependencies": {
-        "yargs": {
-          "version": "16.2.0",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
-          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
-          "requires": {
-            "cliui": "^7.0.2",
-            "escalade": "^3.1.1",
-            "get-caller-file": "^2.0.5",
-            "require-directory": "^2.1.1",
-            "string-width": "^4.2.0",
-            "y18n": "^5.0.5",
-            "yargs-parser": "^20.2.2"
-          }
-        }
-      }
-    },
     "@asciidoctor/core": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-2.2.6.tgz",
-      "integrity": "sha512-TmB2K5UfpDpSbCNBBntXzKHcAk2EA3/P68jmWvmJvglVUdkO9V6kTAuXVe12+h6C4GK0ndwuCrHHtEVcL5t6pQ==",
-      "requires": {
-        "asciidoctor-opal-runtime": "0.3.3",
-        "unxhr": "1.0.1"
-      }
+      "version": "4.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.4.tgz",
+      "integrity": "sha512-MuP8DQq6W/y3SmsglF3FfN2qsafFWAaYkRzuATXuXN4fOxFVXETt1JmlLBPIMZM5uvd48IsFzv5Kb0cIQzRUoQ==",
+      "dev": true
     },
     "@babel/polyfill": {
       "version": "7.12.1",
@@ -2999,30 +2772,6 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
-    "asciidoctor-opal-runtime": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/asciidoctor-opal-runtime/-/asciidoctor-opal-runtime-0.3.3.tgz",
-      "integrity": "sha512-/CEVNiOia8E5BMO9FLooo+Kv18K4+4JBFRJp8vUy/N5dMRAg+fRNV4HA+o6aoSC79jVU/aT5XvUpxSxSsTS8FQ==",
-      "requires": {
-        "glob": "7.1.3",
-        "unxhr": "1.0.1"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-          "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
-      }
-    },
     "async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -3035,11 +2784,6 @@
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
       "dev": true,
       "requires": {}
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
     },
     "bare-events": {
       "version": "2.8.3",
@@ -3112,15 +2856,6 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
-    "brace-expansion": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
-      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
     "braces": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -3174,16 +2909,6 @@
       "resolved": "https://registry.npmjs.org/clear-cut/-/clear-cut-2.0.2.tgz",
       "integrity": "sha512-WVgn/gSejQ+0aoR8ucbKIdo6icduPZW6AbWwyUmAUgxy63rUYjwa5rj/HeoNPhf0/XPrl82X8bO/hwBkSmsFtg=="
     },
-    "cliui": {
-      "version": "7.0.4",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
-      "requires": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.0",
-        "wrap-ansi": "^7.0.0"
-      }
-    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -3215,11 +2940,6 @@
         "normalize-path": "^3.0.0",
         "readable-stream": "^4.0.0"
       }
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "core-js": {
       "version": "2.6.12",
@@ -3499,11 +3219,6 @@
         "universalify": "^2.0.0"
       }
     },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-    },
     "fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -3545,19 +3260,11 @@
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
       "dev": true
     },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "is-binary-path": {
       "version": "2.1.0",
@@ -3667,14 +3374,6 @@
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.0.14.tgz",
       "integrity": "sha512-dn6wd0uw5GsdswPFfsgMp5NSB0/aDe6fK94YJV/AJDYXL6HVLWBsxeq7js7Ad+mU2K9LAlwpk6kN2D5mwCPVow=="
     },
-    "minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
     "mitt": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
@@ -3725,23 +3424,10 @@
         "commander": "^5.1.0"
       }
     },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
     "pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
       "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "pdf-lib": {
       "version": "1.17.1",
@@ -4002,11 +3688,6 @@
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
     },
-    "unxhr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/unxhr/-/unxhr-1.0.1.tgz",
-      "integrity": "sha512-MAhukhVHyaLGDjyDYhy8gVjWJyhTECCdNsLwlMoGFoNJ3o79fpQhtQuzmAE4IxCMDwraF4cW8ZjpAV0m9CRQbg=="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4028,11 +3709,6 @@
         "strip-ansi": "^6.0.0"
       }
     },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
     "ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
@@ -4043,42 +3719,6 @@
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="
-    },
-    "yargs": {
-      "version": "17.6.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-      "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
-      "requires": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "dependencies": {
-        "cliui": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-          "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-          "requires": {
-            "string-width": "^4.2.0",
-            "strip-ansi": "^6.0.1",
-            "wrap-ansi": "^7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "21.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-          "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
-        }
-      }
-    },
-    "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
     },
     "zip-stream": {
       "version": "7.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,10 @@
         "asciidoctor-web-pdf": "bin/asciidoctor-web-pdf"
       },
       "devDependencies": {
-        "@asciidoctor/core": "^4.0.0-alpha.4",
+        "@asciidoctor/core": "^4.0.0-alpha.5",
         "@biomejs/biome": "2.4.15",
         "archiver": "~8.0",
+        "asciidoctor": "^4.0.0-alpha.5",
         "esbuild": "0.28.0",
         "node-html-parser": "~7.1",
         "nunjucks": "~3.2",
@@ -45,13 +46,13 @@
       }
     },
     "node_modules/@asciidoctor/core": {
-      "version": "4.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.4.tgz",
-      "integrity": "sha512-MuP8DQq6W/y3SmsglF3FfN2qsafFWAaYkRzuATXuXN4fOxFVXETt1JmlLBPIMZM5uvd48IsFzv5Kb0cIQzRUoQ==",
+      "version": "4.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.5.tgz",
+      "integrity": "sha512-xwR3hyqmXgZ9W0um4GKveKWY9rjLTpkuu2TINC2m9qXb41X15wqYlWcmMRtdqywawYRsf6kaxR47mHqJpVNu4A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=24"
+        "node": ">=20"
       }
     },
     "node_modules/@babel/polyfill": {
@@ -919,6 +920,23 @@
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
+    },
+    "node_modules/asciidoctor": {
+      "version": "4.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.0-alpha.5.tgz",
+      "integrity": "sha512-6mh4HvwG+mxrRbTTsAY8auqGBfo0RucX7eLAcVQlJ9Ez4CZT43oiaCD0TRos/CA7Tri/sIlDmv3u4mdqlaXcAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asciidoctor/core": "4.0.0-alpha.5"
+      },
+      "bin": {
+        "asciidoctor": "bin/asciidoctor",
+        "asciidoctorjs": "bin/asciidoctor"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/async": {
       "version": "3.2.4",
@@ -2334,9 +2352,9 @@
   },
   "dependencies": {
     "@asciidoctor/core": {
-      "version": "4.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.4.tgz",
-      "integrity": "sha512-MuP8DQq6W/y3SmsglF3FfN2qsafFWAaYkRzuATXuXN4fOxFVXETt1JmlLBPIMZM5uvd48IsFzv5Kb0cIQzRUoQ==",
+      "version": "4.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@asciidoctor/core/-/core-4.0.0-alpha.5.tgz",
+      "integrity": "sha512-xwR3hyqmXgZ9W0um4GKveKWY9rjLTpkuu2TINC2m9qXb41X15wqYlWcmMRtdqywawYRsf6kaxR47mHqJpVNu4A==",
       "dev": true
     },
     "@babel/polyfill": {
@@ -2772,6 +2790,15 @@
       "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
+    "asciidoctor": {
+      "version": "4.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/asciidoctor/-/asciidoctor-4.0.0-alpha.5.tgz",
+      "integrity": "sha512-6mh4HvwG+mxrRbTTsAY8auqGBfo0RucX7eLAcVQlJ9Ez4CZT43oiaCD0TRos/CA7Tri/sIlDmv3u4mdqlaXcAw==",
+      "dev": true,
+      "requires": {
+        "@asciidoctor/core": "4.0.0-alpha.5"
+      }
+    },
     "async": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
@@ -2782,15 +2809,13 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
       "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "bare-events": {
       "version": "2.8.3",
       "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.3.tgz",
       "integrity": "sha512-HdUm8EMQBLaJvGUdidNNbqpA1kYkwNcb+MYxkxCLAPJGQzlv9J0C24h8V65Z4c5GLd/JEALDvpFCQgpLJqc0zw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "bare-fs": {
       "version": "4.7.1",
@@ -3712,8 +3737,7 @@
     "ws": {
       "version": "8.21.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "requires": {}
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -2,8 +2,9 @@
   "name": "asciidoctor-pdf",
   "version": "1.0.0-alpha.16",
   "description": "A PDF converter for AsciiDoc based on web technologies",
+  "type": "module",
   "engines": {
-    "node": ">=18",
+    "node": ">=21",
     "npm": ">=8.0.0"
   },
   "bin": {
@@ -45,6 +46,7 @@
     "@fortawesome/free-regular-svg-icons": "6.2.1",
     "@fortawesome/free-solid-svg-icons": "6.2.1",
     "@ggrossetie/pagedjs": "0.2.0-next.1623590414",
+    "asciidoctor": "^4.0.0-alpha.5",
     "chokidar": "~3.5",
     "file-url": "~3.0",
     "fs-extra": "~11.1.0",
@@ -54,7 +56,6 @@
     "puppeteer": "25.1.0"
   },
   "devDependencies": {
-    "@asciidoctor/core": "^4.0.0-alpha.4",
     "@biomejs/biome": "2.4.15",
     "archiver": "~8.0",
     "esbuild": "0.28.0",
@@ -64,6 +65,6 @@
     "postject": "1.0.0-alpha.6"
   },
   "peerDependencies": {
-    "@asciidoctor/core": "^4.0.0-alpha.4"
+    "asciidoctor": ">= 4.0.0-alpha.5 < 5"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@fortawesome/free-regular-svg-icons": "6.2.1",
     "@fortawesome/free-solid-svg-icons": "6.2.1",
     "@ggrossetie/pagedjs": "0.2.0-next.1623590414",
-    "asciidoctor": "^4.0.0-alpha.5",
+    "asciidoctor": ">= 4.0.0-alpha.5 < 5",
     "chokidar": "~3.5",
     "file-url": "~3.0",
     "fs-extra": "~11.1.0",
@@ -57,6 +57,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "2.4.15",
+    "@puppeteer/browsers": "~3.0",
     "archiver": "~8.0",
     "esbuild": "0.28.0",
     "node-html-parser": "~7.1",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
   },
   "homepage": "https://github.com/ggrossetie/asciidoctor-web-pdf#readme",
   "dependencies": {
-    "@asciidoctor/cli": "~3.5",
     "@fortawesome/fontawesome-svg-core": "6.2.1",
     "@fortawesome/free-brands-svg-icons": "6.2.1",
     "@fortawesome/free-regular-svg-icons": "6.2.1",
@@ -52,11 +51,10 @@
     "html-entities": "~2.3",
     "mathjax": "3.2.2",
     "pdf-lib": "~1.17",
-    "puppeteer": "25.1.0",
-    "yargs": "17.6.2"
+    "puppeteer": "25.1.0"
   },
   "devDependencies": {
-    "@asciidoctor/core": "~2.2",
+    "@asciidoctor/core": "^4.0.0-alpha.4",
     "@biomejs/biome": "2.4.15",
     "archiver": "~8.0",
     "esbuild": "0.28.0",
@@ -66,6 +64,6 @@
     "postject": "1.0.0-alpha.6"
   },
   "peerDependencies": {
-    "@asciidoctor/core": "~2.2"
+    "@asciidoctor/core": "^4.0.0-alpha.4"
   }
 }

--- a/tasks/prepare-binaries.js
+++ b/tasks/prepare-binaries.js
@@ -3,11 +3,11 @@ import fs from 'node:fs'
 import { createRequire } from 'node:module'
 import path from 'node:path'
 import { Browser, detectBrowserPlatform, install } from '@puppeteer/browsers'
-import archiver from 'archiver'
 import esbuild from 'esbuild'
 import fsExtra from 'fs-extra'
 
 const require = createRequire(import.meta.url)
+const archiver = require('archiver')
 
 const appName = 'asciidoctor-web-pdf'
 const buildDir = 'build'
@@ -44,6 +44,10 @@ async function bundle() {
     target: [`node${nodeMajor}`],
     outfile: bundlePath,
     loader: { '': 'js' },
+    define: {
+      'import.meta.url': '__filename',
+      'import.meta.dirname': '__dirname',
+    },
     external: [
       // Native addon - chokidar falls back to polling without it
       'fsevents',

--- a/tasks/prepare-binaries.js
+++ b/tasks/prepare-binaries.js
@@ -1,18 +1,17 @@
-const path = require('node:path')
-const fs = require('node:fs')
-const fsExtra = require('fs-extra')
-const archiver = require('archiver')
-const {
-  install,
-  detectBrowserPlatform,
-  Browser,
-} = require('@puppeteer/browsers')
-const { execSync, execFileSync } = require('node:child_process')
-const esbuild = require('esbuild')
+import { execFileSync, execSync } from 'node:child_process'
+import fs from 'node:fs'
+import { createRequire } from 'node:module'
+import path from 'node:path'
+import { Browser, detectBrowserPlatform, install } from '@puppeteer/browsers'
+import archiver from 'archiver'
+import esbuild from 'esbuild'
+import fsExtra from 'fs-extra'
+
+const require = createRequire(import.meta.url)
 
 const appName = 'asciidoctor-web-pdf'
 const buildDir = 'build'
-const rootDirPath = path.join(__dirname, '..')
+const rootDirPath = path.join(import.meta.dirname, '..')
 const buildDirPath = path.join(rootDirPath, buildDir)
 const version = require('../package.json').version
 const nodeMajor = parseInt(process.version.slice(1), 10)
@@ -248,11 +247,9 @@ async function main() {
   console.log('Done!')
 }
 
-;(async () => {
-  try {
-    await main()
-  } catch (err) {
-    console.error(err)
-    process.exit(1)
-  }
-})()
+try {
+  await main()
+} catch (err) {
+  console.error(err)
+  process.exit(1)
+}

--- a/tasks/update-font-face.js
+++ b/tasks/update-font-face.js
@@ -1,7 +1,8 @@
-const fs = require('node:fs')
-const ospath = require('node:path')
-const cssDirectoryPath = ospath.join(__dirname, '..', 'css')
-const fontsDirectoryPath = ospath.join(__dirname, '..', 'fonts')
+import fs from 'node:fs'
+import ospath from 'node:path'
+
+const cssDirectoryPath = ospath.join(import.meta.dirname, '..', 'css')
+const fontsDirectoryPath = ospath.join(import.meta.dirname, '..', 'fonts')
 const fonts = fs.readdirSync(fontsDirectoryPath)
 
 // generate the @font-face definitions from the fonts directory
@@ -10,7 +11,7 @@ const endTag = '/* end:font-face */'
 const data = []
 data.push(startTag)
 data.push(
-  `/* Generated using ${ospath.relative(ospath.join(__dirname, '..'), __filename)} script */`,
+  `/* Generated using ${ospath.relative(ospath.join(import.meta.dirname, '..'), import.meta.filename)} script */`,
 )
 data.push('/* DO NOT MANUALLY EDIT */')
 for (const font of fonts) {

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -1,10 +1,11 @@
 const { describe, it } = require('node:test')
 const assert = require('node:assert/strict')
 
-const { PdfOptions, PdfInvoker, processor } = require('../lib/cli.js')
+const { convert } = require('@asciidoctor/core')
+const { PdfOptions, PdfInvoker } = require('../lib/cli.js')
 
 describe('CLI', () => {
-  it('should set the env attributes', () => {
+  it('should set the env attributes', async () => {
     const options = new PdfOptions().parse([
       'node',
       'asciidoctor-pdf',
@@ -14,7 +15,7 @@ describe('CLI', () => {
     const attributes = pdfInvoker.options.options.attributes
     assert.ok(attributes.includes('env-web-pdf'))
     assert.ok(attributes.includes('env=web-pdf'))
-    const html = processor.convert(
+    const html = await convert(
       '{env}',
       Object.assign({}, pdfInvoker.options.options, { standalone: false }),
     )
@@ -25,7 +26,7 @@ describe('CLI', () => {
 </div>`,
     )
   })
-  it('should override the default env attributes', () => {
+  it('should override the default env attributes', async () => {
     const options = new PdfOptions().parse([
       'node',
       'asciidoctor-pdf',
@@ -38,7 +39,7 @@ describe('CLI', () => {
     assert.ok(attributes.includes('env-web-pdf'))
     assert.ok(attributes.includes('env=web-pdf'))
     assert.ok(attributes.includes('env=pdf'))
-    const html = processor.convert(
+    const html = await convert(
       '{env}',
       Object.assign({}, pdfInvoker.options.options, { standalone: false }),
     )

--- a/test/cli_test.js
+++ b/test/cli_test.js
@@ -1,8 +1,8 @@
-const { describe, it } = require('node:test')
-const assert = require('node:assert/strict')
+import assert from 'node:assert/strict'
+import { describe, it } from 'node:test'
 
-const { convert } = require('@asciidoctor/core')
-const { PdfOptions, PdfInvoker } = require('../lib/cli.js')
+import { convert } from '@asciidoctor/core'
+import { PdfInvoker, PdfOptions } from '../lib/cli.js'
 
 describe('CLI', () => {
   it('should set the env attributes', async () => {

--- a/test/document_convert_test.js
+++ b/test/document_convert_test.js
@@ -1,11 +1,11 @@
-const { describe, it } = require('node:test')
-const assert = require('node:assert/strict')
-const { parse } = require('node-html-parser')
-const ospath = require('node:path')
+import assert from 'node:assert/strict'
+import ospath from 'node:path'
+import { describe, it } from 'node:test'
+import { ConverterFactory, convertFile, load } from '@asciidoctor/core'
+import { parse } from 'node-html-parser'
+import DocumentConverter from '../lib/document/document-converter.js'
 
-const { load, convertFile, ConverterFactory } = require('@asciidoctor/core')
-const DocumentConverter = require('../lib/document/document-converter')
-
+const __dirname = import.meta.dirname
 const fixturesPath = (...paths) => ospath.join(__dirname, 'fixtures', ...paths)
 
 describe('Document converter', () => {

--- a/test/document_convert_test.js
+++ b/test/document_convert_test.js
@@ -3,23 +3,21 @@ const assert = require('node:assert/strict')
 const { parse } = require('node-html-parser')
 const ospath = require('node:path')
 
-const asciidoctor = require('@asciidoctor/core')()
+const { load, convertFile, ConverterFactory } = require('@asciidoctor/core')
 const DocumentConverter = require('../lib/document/document-converter')
 
 const fixturesPath = (...paths) => ospath.join(__dirname, 'fixtures', ...paths)
 
 describe('Document converter', () => {
-  it('should override the titlePage function', () => {
+  it('should override the titlePage function', async () => {
     class CustomDocumentConverter extends DocumentConverter {
       titlePage(_node) {
         return '<h1>Static title</h1>'
       }
     }
 
-    asciidoctor.ConverterFactory.register(new CustomDocumentConverter(), [
-      'custom-web-pdf',
-    ])
-    const doc = asciidoctor.load(
+    ConverterFactory.register(new CustomDocumentConverter(), ['custom-web-pdf'])
+    const doc = await load(
       `= Title
 Guillaume Grossetie
 :title-page:
@@ -27,20 +25,18 @@ Guillaume Grossetie
 == Section`,
       { backend: 'custom-web-pdf' },
     )
-    const root = parse(doc.convert({ header_footer: true }))
+    const root = parse(await doc.convert({ header_footer: true }))
     assert.strictEqual(root.querySelector('h1')?.textContent, 'Static title')
   })
 
   describe('Docinfo', () => {
-    it('should include shared (head) docinfo', () => {
-      asciidoctor.ConverterFactory.register(new DocumentConverter(), [
-        'web-pdf',
-      ])
+    it('should include shared (head) docinfo', async () => {
+      ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
       const root = parse(
-        asciidoctor.convertFile(fixturesPath('simple.adoc'), {
+        await convertFile(fixturesPath('simple.adoc'), {
           safe: 'safe',
           backend: 'web-pdf',
-          header_footer: true,
+          standalone: true,
           to_file: false,
           attributes: { docinfo: 'shared' },
         }),
@@ -56,15 +52,13 @@ Guillaume Grossetie
         1,
       )
     })
-    it('should include private (footer) docinfo', () => {
-      asciidoctor.ConverterFactory.register(new DocumentConverter(), [
-        'web-pdf',
-      ])
+    it('should include private (footer) docinfo', async () => {
+      ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
       const root = parse(
-        asciidoctor.convertFile(fixturesPath('simple.adoc'), {
+        await convertFile(fixturesPath('simple.adoc'), {
           safe: 'safe',
           backend: 'web-pdf',
-          header_footer: true,
+          standalone: true,
           to_file: false,
           attributes: { docinfo: 'private-footer' },
         }),
@@ -74,15 +68,13 @@ Guillaume Grossetie
         'This is the end.',
       )
     })
-    it('should include private (running) docinfo', () => {
-      asciidoctor.ConverterFactory.register(new DocumentConverter(), [
-        'web-pdf',
-      ])
+    it('should include private (running) docinfo', async () => {
+      ConverterFactory.register(new DocumentConverter(), ['web-pdf'])
       const root = parse(
-        asciidoctor.convertFile(fixturesPath('simple.adoc'), {
+        await convertFile(fixturesPath('simple.adoc'), {
           safe: 'safe',
           backend: 'web-pdf',
-          header_footer: true,
+          standalone: true,
           to_file: false,
           attributes: { docinfo: 'private-running' },
         }),

--- a/test/helper.js
+++ b/test/helper.js
@@ -1,9 +1,11 @@
-const ospath = require('node:path')
-const fs = require('node:fs')
-const os = require('node:os')
-const childProcess = require('node:child_process')
-const PNG = require('pngjs').PNG
-const { default: pixelmatch } = require('pixelmatch')
+import childProcess from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import ospath from 'node:path'
+import { default as pixelmatch } from 'pixelmatch'
+import { PNG } from 'pngjs'
+
+const __dirname = import.meta.dirname
 
 function outputDir() {
   return ospath.join(__dirname, 'output')
@@ -30,7 +32,7 @@ function computeImageDifferences(referenceBuffer, actualBuffer, diffFilename) {
   return numDiffPixels
 }
 
-function toVisuallyMatch(referenceFilename, actualPath) {
+export function toVisuallyMatch(referenceFilename, actualPath) {
   const platform = os.platform() === 'darwin' ? 'macos' : 'linux'
   let referencePath
   if (ospath.isAbsolute(referenceFilename)) {
@@ -109,5 +111,3 @@ function toVisuallyMatch(referenceFilename, actualPath) {
   }
   return pixels
 }
-
-module.exports = { toVisuallyMatch }

--- a/test/helper.js
+++ b/test/helper.js
@@ -3,7 +3,7 @@ const fs = require('node:fs')
 const os = require('node:os')
 const childProcess = require('node:child_process')
 const PNG = require('pngjs').PNG
-const pixelmatch = require('pixelmatch')
+const { default: pixelmatch } = require('pixelmatch')
 
 function outputDir() {
   return ospath.join(__dirname, 'output')

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -2,7 +2,7 @@ const { describe, it } = require('node:test')
 const assert = require('node:assert/strict')
 const { PDFDocument, PDFName, PDFHexString } = require('pdf-lib')
 
-const asciidoctor = require('@asciidoctor/core')()
+const { load } = require('@asciidoctor/core')
 const { addMetadata } = require('../lib/metadata.js')
 const { version: pkgVersion } = require('../package.json')
 
@@ -36,7 +36,7 @@ const assertMetadataEqual = (pdf, metadataKey, expectedValue) => {
 }
 
 const toPdfWithMetadata = async (content, options) => {
-  const doc = asciidoctor.load(content, options)
+  const doc = await load(content, options)
   const pdfDoc = await PDFDocument.create()
   return addMetadata(pdfDoc, doc)
 }

--- a/test/metadata_test.js
+++ b/test/metadata_test.js
@@ -1,9 +1,11 @@
-const { describe, it } = require('node:test')
-const assert = require('node:assert/strict')
-const { PDFDocument, PDFName, PDFHexString } = require('pdf-lib')
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import { describe, it } from 'node:test'
+import { load } from '@asciidoctor/core'
+import { PDFDocument, PDFHexString, PDFName } from 'pdf-lib'
+import { addMetadata } from '../lib/metadata.js'
 
-const { load } = require('@asciidoctor/core')
-const { addMetadata } = require('../lib/metadata.js')
+const require = createRequire(import.meta.url)
 const { version: pkgVersion } = require('../package.json')
 
 const decodePDFHexValue = (value) => {

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -1,22 +1,24 @@
-const {
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import ospath from 'node:path'
+import {
+  after,
+  afterEach,
+  before,
+  beforeEach,
   describe,
   it,
-  before,
-  after,
-  beforeEach,
-  afterEach,
   mock,
-} = require('node:test')
-const assert = require('node:assert/strict')
-const fs = require('node:fs')
-const { PDFDocument, PDFName, PDFDict } = require('pdf-lib')
-const ospath = require('node:path')
-const helper = require('./helper.js')
+} from 'node:test'
+import { PDFDict, PDFDocument, PDFName } from 'pdf-lib'
+import Browser from '../lib/browser.js'
+import * as converter from '../lib/converter.js'
+import { templates } from '../lib/document/document-converter.js'
+import * as helper from './helper.js'
 
-const converter = require('../lib/converter.js')
-const { templates } = require('../lib/document/document-converter')
 converter.registerTemplateConverter(templates)
 
+const __dirname = import.meta.dirname
 const fixturesPath = (...paths) => ospath.join(__dirname, 'fixtures', ...paths)
 const outputPath = (...paths) => ospath.join(__dirname, 'output', ...paths)
 const cssPath = (...paths) => ospath.join(__dirname, '..', 'css', ...paths)
@@ -450,10 +452,12 @@ describe('PDF converter', () => {
     })
 
     it('should timeout while navigating', async () => {
+      const timeoutError = new Error('Navigation timeout of 1 ms exceeded')
+      timeoutError.name = 'TimeoutError'
+      const gotoMock = mock.method(Browser.prototype, 'goto', async () => {
+        throw timeoutError
+      })
       try {
-        process.env.PUPPETEER_NAVIGATION_TIMEOUT = 1
-        delete require.cache[require.resolve('../lib/converter.js')]
-        const converter = require('../lib/converter.js')
         await converter.convert(
           { path: fixturesPath('title-page.adoc') },
           {},
@@ -465,7 +469,7 @@ describe('PDF converter', () => {
           'Unable to generate the PDF - Error: TimeoutError: Navigation timeout of 1 ms exceeded',
         )
       } finally {
-        delete process.env.PUPPETEER_NAVIGATION_TIMEOUT
+        gotoMock.mock.restore()
       }
     })
   })

--- a/test/pdf_test.js
+++ b/test/pdf_test.js
@@ -13,10 +13,9 @@ const { PDFDocument, PDFName, PDFDict } = require('pdf-lib')
 const ospath = require('node:path')
 const helper = require('./helper.js')
 
-const asciidoctor = require('@asciidoctor/core')()
 const converter = require('../lib/converter.js')
 const { templates } = require('../lib/document/document-converter')
-converter.registerTemplateConverter(asciidoctor, templates)
+converter.registerTemplateConverter(templates)
 
 const fixturesPath = (...paths) => ospath.join(__dirname, 'fixtures', ...paths)
 const outputPath = (...paths) => ospath.join(__dirname, 'output', ...paths)
@@ -78,7 +77,7 @@ describe('PDF converter', () => {
   const convert = async (inputFile, outputFile, options) => {
     const opts = options || {}
     opts.to_file = outputFile
-    await converter.convert(asciidoctor, { path: inputFile }, opts, false)
+    await converter.convert({ path: inputFile }, opts, false)
     return PDFDocument.load(fs.readFileSync(outputFile))
   }
 
@@ -96,7 +95,6 @@ describe('PDF converter', () => {
     opts.attributes.reproducible = ''
     opts.to_file = outputFile
     await converter.convert(
-      asciidoctor,
       { path: fixturesPath(`${inputBaseFileName}.adoc`) },
       opts,
       false,
@@ -457,7 +455,6 @@ describe('PDF converter', () => {
         delete require.cache[require.resolve('../lib/converter.js')]
         const converter = require('../lib/converter.js')
         await converter.convert(
-          asciidoctor,
           { path: fixturesPath('title-page.adoc') },
           {},
           false,

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -3,38 +3,38 @@ const assert = require('node:assert/strict')
 const ospath = require('node:path')
 const { parse } = require('node-html-parser')
 
-const asciidoctor = require('@asciidoctor/core')()
+const { load, convert } = require('@asciidoctor/core')
 const converter = require('../lib/converter.js')
 const { templates } = require('../lib/document/document-converter')
-converter.registerTemplateConverter(asciidoctor, templates)
+converter.registerTemplateConverter(templates)
 
 const fixturesPath = (...paths) => ospath.join(__dirname, 'fixtures', ...paths)
 
 describe('Default converter', () => {
   describe('Language', () => {
-    it('should have a default language', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should have a default language', async () => {
+      const doc = await load(`= Title
 
 == Section`)
-      const root = parse(templates.document(doc))
+      const root = parse(await templates.document(doc))
       assert.strictEqual(root.querySelector('html').getAttribute('lang'), 'en')
     })
 
-    it('respect the document lang attribute', () => {
-      const doc = asciidoctor.load(`= Title
+    it('respect the document lang attribute', async () => {
+      const doc = await load(`= Title
 :lang: de
 
 == Section`)
-      const root = parse(templates.document(doc))
+      const root = parse(await templates.document(doc))
       assert.strictEqual(root.querySelector('html').getAttribute('lang'), 'de')
     })
 
-    it('respect the document nolang attribute', () => {
-      const doc = asciidoctor.load(`= Title
+    it('respect the document nolang attribute', async () => {
+      const doc = await load(`= Title
 :nolang:
 
 == Section`)
-      const root = parse(templates.document(doc))
+      const root = parse(await templates.document(doc))
       assert.strictEqual(
         root.querySelector('html').getAttribute('lang') ?? undefined,
         undefined,
@@ -43,54 +43,54 @@ describe('Default converter', () => {
   })
 
   describe('Page title', () => {
-    it('should include a title page if title-page attribute is defined', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should include a title page if title-page attribute is defined', async () => {
+      const doc = await load(`= Title
 Guillaume Grossetie
 :title-page:
 
 == Section`)
-      const root = parse(doc.convert({ header_footer: true }))
+      const root = parse(await doc.convert({ standalone: true }))
       assert.strictEqual(
         root.querySelector('.title-page > h1')?.textContent,
         'Title',
       )
     })
 
-    it('should include a title page if doctype is book', () => {
-      const doc = asciidoctor.load(
+    it('should include a title page if doctype is book', async () => {
+      const doc = await load(
         `= Title
 Guillaume Grossetie
 
 == Section`,
         { doctype: 'book' },
       )
-      const root = parse(doc.convert({ header_footer: true }))
+      const root = parse(await doc.convert({ standalone: true }))
       assert.strictEqual(
         root.querySelector('.title-page > h1')?.textContent,
         'Title',
       )
     })
 
-    it('should not include a title page', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should not include a title page', async () => {
+      const doc = await load(`= Title
 Guillaume Grossetie
 
 == Section`)
-      const root = parse(doc.convert({ header_footer: true }))
+      const root = parse(await doc.convert({ standalone: true }))
       assert.strictEqual(root.querySelectorAll('.title-page > h1').length, 0)
     })
 
-    it('should not include a title page if the document title is empty', () => {
-      const doc = asciidoctor.load('Hello world!', {
+    it('should not include a title page if the document title is empty', async () => {
+      const doc = await load('Hello world!', {
         attributes: { 'title-page': '' },
       })
-      const root = parse(doc.convert({ header_footer: true }))
+      const root = parse(await doc.convert({ standalone: true }))
       assert.strictEqual(root.querySelectorAll('.title-page > h1').length, 0)
     })
 
-    it('should not include a document title if the document title is empty', () => {
-      const doc = asciidoctor.load('Hello world!')
-      const root = parse(doc.convert({ header_footer: true }))
+    it('should not include a document title if the document title is empty', async () => {
+      const doc = await load('Hello world!')
+      const root = parse(await doc.convert({ standalone: true }))
       assert.strictEqual(
         root.querySelectorAll('.title-document > h1').length,
         0,
@@ -98,11 +98,11 @@ Guillaume Grossetie
     })
   })
 
-  it('should replace the default stylesheet with a custom stylesheet', () => {
-    const doc = asciidoctor.load('[.greetings]#Hello world#', {
+  it('should replace the default stylesheet with a custom stylesheet', async () => {
+    const doc = await load('[.greetings]#Hello world#', {
       attributes: { stylesheet: fixturesPath('custom.css') },
     })
-    const root = parse(doc.convert({ header_footer: true }))
+    const root = parse(await doc.convert({ standalone: true }))
     assert.ok(
       !root
         .querySelector('head')
@@ -115,13 +115,13 @@ Guillaume Grossetie
     )
   })
 
-  it('should load multiple stylesheets', () => {
-    const doc = asciidoctor.load('Hello world', {
+  it('should load multiple stylesheets', async () => {
+    const doc = await load('Hello world', {
       attributes: {
         stylesheet: `${fixturesPath('variable.css')}, ,${fixturesPath('theme.css')},`,
       },
     })
-    const root = parse(doc.convert({ header_footer: true }))
+    const root = parse(await doc.convert({ standalone: true }))
     assert.ok(
       !root
         .querySelector('head')
@@ -140,19 +140,18 @@ Guillaume Grossetie
     )
   })
 
-  it('should resolve the stylesheet when using a relative path', () => {
-    const doc = asciidoctor.load('[.greetings]#Hello world#', {
+  it('should resolve the stylesheet when using a relative path', async () => {
+    const doc = await load('[.greetings]#Hello world#', {
       attributes: {
         stylesheet: ospath.join(
           '@asciidoctor',
           'core',
-          'dist',
-          'css',
-          'asciidoctor.css',
+          'data',
+          'asciidoctor-default.css',
         ),
       },
     })
-    const root = parse(doc.convert({ header_footer: true }))
+    const root = parse(await doc.convert({ standalone: true }))
     assert.ok(
       !root
         .querySelector('head')
@@ -165,9 +164,8 @@ Guillaume Grossetie
         'node_modules',
         '@asciidoctor',
         'core',
-        'dist',
-        'css',
-        'asciidoctor.css',
+        'data',
+        'asciidoctor-default.css',
       ),
     )
     assert.strictEqual(
@@ -182,17 +180,16 @@ Guillaume Grossetie
       require.resolve('mathjax/es5/tex-chtml-full.js'),
     )
 
-    it('should include MathML when stem is set', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should include MathML when stem is set', async () => {
+      const doc = await load(`= Title
 :stem:
 
 == Section`)
-      const root = parse(templates.document(doc))
+      const root = parse(await templates.document(doc))
       assert.strictEqual(
         root.querySelectorAll(`script[src="${mathjaxFileUrl}"]`).length,
         1,
       )
-      // by default equation numbering is not enabled
       assert.ok(
         root
           .querySelector('script[data-type="mathjax-config"]')
@@ -200,36 +197,36 @@ Guillaume Grossetie
       )
     })
 
-    it('should not include MathML when stem is not set', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should not include MathML when stem is not set', async () => {
+      const doc = await load(`= Title
 :stem!:
 
 == Section`)
-      const root = parse(templates.document(doc))
+      const root = parse(await templates.document(doc))
       assert.strictEqual(
         root.querySelectorAll(`script[src="${mathjaxFileUrl}"]`).length,
         0,
       )
     })
 
-    it('should not include MathML when stem is not present', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should not include MathML when stem is not present', async () => {
+      const doc = await load(`= Title
 
 == Section`)
-      const root = parse(templates.document(doc))
+      const root = parse(await templates.document(doc))
       assert.strictEqual(
         root.querySelectorAll(`script[src="${mathjaxFileUrl}"]`).length,
         0,
       )
     })
 
-    it('should add equation numbers when eqnums equals AMS', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should add equation numbers when eqnums equals AMS', async () => {
+      const doc = await load(`= Title
 :stem:
 :eqnums: AMS
 
 == Section`)
-      const root = parse(templates.document(doc))
+      const root = parse(await templates.document(doc))
       assert.strictEqual(
         root.querySelectorAll(`script[src="${mathjaxFileUrl}"]`).length,
         1,
@@ -241,18 +238,17 @@ Guillaume Grossetie
       )
     })
 
-    it('should add equation numbers when eqnums is present', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should add equation numbers when eqnums is present', async () => {
+      const doc = await load(`= Title
 :stem:
 :eqnums:
 
 == Section`)
-      const root = parse(templates.document(doc))
+      const root = parse(await templates.document(doc))
       assert.strictEqual(
         root.querySelectorAll(`script[src="${mathjaxFileUrl}"]`).length,
         1,
       )
-      // If eqnums is empty, the value will be "ams"
       assert.ok(
         root
           .querySelector('script[data-type="mathjax-config"]')
@@ -260,13 +256,13 @@ Guillaume Grossetie
       )
     })
 
-    it('should add equation numbers when eqnums equals all', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should add equation numbers when eqnums equals all', async () => {
+      const doc = await load(`= Title
 :stem:
 :eqnums: all
 
 == Section`)
-      const root = parse(templates.document(doc))
+      const root = parse(await templates.document(doc))
       assert.strictEqual(
         root.querySelectorAll(`script[src="${mathjaxFileUrl}"]`).length,
         1,
@@ -280,13 +276,13 @@ Guillaume Grossetie
   })
 
   describe('Admonition', () => {
-    it('should use an emoji shortcode as admonition icon', () => {
-      const doc = asciidoctor.load(`= Title
+    it('should use an emoji shortcode as admonition icon', async () => {
+      const doc = await load(`= Title
 :tip-caption: :bulb:
 
 [TIP]
 It's possible to use emojis as admonition.`)
-      const root = parse(doc.convert())
+      const root = parse(await doc.convert())
       assert.strictEqual(
         root.querySelector('td.icon > .title').innerHTML,
         ':bulb:',
@@ -296,48 +292,48 @@ It's possible to use emojis as admonition.`)
 
   describe('Inline icon', () => {
     describe('FontAwesome SVG icons set', () => {
-      it('should enable SVG icon when icons attribute is equals to font (user experience)', () => {
-        const doc = asciidoctor.load(
+      it('should enable SVG icon when icons attribute is equals to font (user experience)', async () => {
+        const doc = await load(
           `= Title
 :icons: font
 
 icon:address-book[]`,
           { safe: 'safe' },
         )
-        const root = parse(doc.convert())
+        const root = parse(await doc.convert())
         assert.strictEqual(
           root.querySelector('svg[data-prefix="fas"][data-icon="address-book"]')
             .innerHTML,
           '<path fill="currentColor" d="M96 0C60.7 0 32 28.7 32 64V448c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V64c0-35.3-28.7-64-64-64H96zM208 288h64c44.2 0 80 35.8 80 80c0 8.8-7.2 16-16 16H144c-8.8 0-16-7.2-16-16c0-44.2 35.8-80 80-80zm96-96c0 35.3-28.7 64-64 64s-64-28.7-64-64s28.7-64 64-64s64 28.7 64 64zM512 80c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V80zM496 192c-8.8 0-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm16 144c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V336z"></path>',
         )
       })
-      it('should render a solid FontAwesome SVG icon (default)', () => {
-        const doc = asciidoctor.load(`:icontype: svg
+      it('should render a solid FontAwesome SVG icon (default)', async () => {
+        const doc = await load(`:icontype: svg
 
 icon:address-book[]`)
-        const root = parse(doc.convert())
+        const root = parse(await doc.convert())
         assert.strictEqual(
           root.querySelector('svg[data-prefix="fas"][data-icon="address-book"]')
             .innerHTML,
           '<path fill="currentColor" d="M96 0C60.7 0 32 28.7 32 64V448c0 35.3 28.7 64 64 64H384c35.3 0 64-28.7 64-64V64c0-35.3-28.7-64-64-64H96zM208 288h64c44.2 0 80 35.8 80 80c0 8.8-7.2 16-16 16H144c-8.8 0-16-7.2-16-16c0-44.2 35.8-80 80-80zm96-96c0 35.3-28.7 64-64 64s-64-28.7-64-64s28.7-64 64-64s64 28.7 64 64zM512 80c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V80zM496 192c-8.8 0-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V208c0-8.8-7.2-16-16-16zm16 144c0-8.8-7.2-16-16-16s-16 7.2-16 16v64c0 8.8 7.2 16 16 16s16-7.2 16-16V336z"></path>',
         )
       })
-      it('should render a regular FontAwesome SVG icon (default)', () => {
-        const doc = asciidoctor.load(`:icontype: svg
+      it('should render a regular FontAwesome SVG icon (default)', async () => {
+        const doc = await load(`:icontype: svg
 
 icon:address-book[set=far]`)
-        const root = parse(doc.convert())
+        const root = parse(await doc.convert())
         assert.strictEqual(
           root.querySelector('svg[data-prefix="far"][data-icon="address-book"]')
             .innerHTML,
           '<path fill="currentColor" d="M272 288h-64C163.8 288 128 323.8 128 368C128 376.8 135.2 384 144 384h192c8.836 0 16-7.164 16-16C352 323.8 316.2 288 272 288zM240 256c35.35 0 64-28.65 64-64s-28.65-64-64-64c-35.34 0-64 28.65-64 64S204.7 256 240 256zM496 320H480v96h16c8.836 0 16-7.164 16-16v-64C512 327.2 504.8 320 496 320zM496 64H480v96h16C504.8 160 512 152.8 512 144v-64C512 71.16 504.8 64 496 64zM496 192H480v96h16C504.8 288 512 280.8 512 272v-64C512 199.2 504.8 192 496 192zM384 0H96C60.65 0 32 28.65 32 64v384c0 35.35 28.65 64 64 64h288c35.35 0 64-28.65 64-64V64C448 28.65 419.3 0 384 0zM400 448c0 8.836-7.164 16-16 16H96c-8.836 0-16-7.164-16-16V64c0-8.838 7.164-16 16-16h288c8.836 0 16 7.162 16 16V448z"></path>',
         )
       })
-      it('should render a brand FontAwesome SVG icon (default)', () => {
-        const doc = asciidoctor.load(`:icontype: svg
+      it('should render a brand FontAwesome SVG icon (default)', async () => {
+        const doc = await load(`:icontype: svg
 
 icon:chrome@fab[]`)
-        const root = parse(doc.convert())
+        const root = parse(await doc.convert())
         assert.strictEqual(
           root.querySelector('svg[data-prefix="fab"][data-icon="chrome"]')
             .innerHTML,
@@ -348,8 +344,8 @@ icon:chrome@fab[]`)
   })
 
   describe('Table Of Contents', () => {
-    it('should add a toc when toc is set', () => {
-      const doc = asciidoctor.load(
+    it('should add a toc when toc is set', async () => {
+      const doc = await load(
         `= Title
 :toc:
 
@@ -360,30 +356,30 @@ icon:chrome@fab[]`)
 == Section 3`,
         { safe: 'safe' },
       )
-      const root = parse(doc.convert())
+      const root = parse(await doc.convert())
       assert.strictEqual(
         root.querySelectorAll('#toc > ul.sectlevel1 > li').length,
         3,
       )
     })
 
-    it("should not add a toc when there's no section", () => {
-      const doc = asciidoctor.load(
+    it("should not add a toc when there's no section", async () => {
+      const doc = await load(
         `= Title
 :toc:
 
 Just a preamble.`,
         { safe: 'safe' },
       )
-      const root = parse(doc.convert())
+      const root = parse(await doc.convert())
       assert.strictEqual(
         root.querySelectorAll('#toc > ul.sectlevel1 > li').length,
         0,
       )
     })
 
-    it('should not add a toc in the header when toc placement is macro', () => {
-      const doc = asciidoctor.load(
+    it('should not add a toc in the header when toc placement is macro', async () => {
+      const doc = await load(
         `= Title
 :toc: macro
 
@@ -394,15 +390,15 @@ Just a preamble.`,
 == Section 3`,
         { safe: 'safe' },
       )
-      const root = parse(doc.convert())
+      const root = parse(await doc.convert())
       assert.strictEqual(
         root.querySelectorAll('#toc > ul.sectlevel1 > li').length,
         0,
       )
     })
 
-    it('should use a template directory (Nunjucks)', () => {
-      const html = asciidoctor.convert('Hello *world*', {
+    it('should use a template directory (Nunjucks)', async () => {
+      const html = await convert('Hello *world*', {
         template_dirs: [fixturesPath('templates', 'nunjucks')],
       })
       assert.strictEqual(

--- a/test/templates_test.js
+++ b/test/templates_test.js
@@ -1,14 +1,20 @@
-const { describe, it } = require('node:test')
-const assert = require('node:assert/strict')
-const ospath = require('node:path')
-const { parse } = require('node-html-parser')
+import assert from 'node:assert/strict'
+import { createRequire } from 'node:module'
+import ospath from 'node:path'
+import { describe, it } from 'node:test'
+import { convert, load } from '@asciidoctor/core'
+import fileUrl from 'file-url'
+import { parse } from 'node-html-parser'
+import * as converter from '../lib/converter.js'
+import { templates } from '../lib/document/document-converter.js'
 
-const { load, convert } = require('@asciidoctor/core')
-const converter = require('../lib/converter.js')
-const { templates } = require('../lib/document/document-converter')
 converter.registerTemplateConverter(templates)
 
+const require = createRequire(import.meta.url)
+const __dirname = import.meta.dirname
 const fixturesPath = (...paths) => ospath.join(__dirname, 'fixtures', ...paths)
+
+const mathjaxFileUrl = fileUrl(require.resolve('mathjax/es5/tex-chtml-full.js'))
 
 describe('Default converter', () => {
   describe('Language', () => {
@@ -175,11 +181,6 @@ Guillaume Grossetie
   })
 
   describe('Stem', () => {
-    const fileUrl = require('file-url')
-    const mathjaxFileUrl = fileUrl(
-      require.resolve('mathjax/es5/tex-chtml-full.js'),
-    )
-
     it('should include MathML when stem is set', async () => {
       const doc = await load(`= Title
 :stem:


### PR DESCRIPTION
- Update @asciidoctor/core from ~2.2 to ^4.0.0-alpha.5 (pure JS rewrite, no Opal/Ruby)
- Remove @asciidoctor/cli and yargs dependencies; rewrite CLI with `asciidoctor/cli`
- Adapt all API calls: named exports, async convert/load, camelCase node properties, plain doc.attributes object, new Html5Converter('html5'), ConverterFactory singleton
- Add handles() method to TemplateConverter for CompositeConverter compatibility
- Fix stem.js: getAttribute returns null (not undefined) in v4
- Fix titlePage: getAuthor() returns null in v4 when no author is set
- Fix resolveStylesheet: fallback for ERR_PACKAGE_PATH_NOT_EXPORTED (strict exports)
- Fix pixelmatch v7 import: use destructured default export
- Update tests: async/await throughout, standalone:true, v4 import patterns